### PR TITLE
refactor: Optimize vzip_s8

### DIFF
--- a/neon2rvv.h
+++ b/neon2rvv.h
@@ -2476,17 +2476,15 @@ FORCE_INLINE int8x8x2_t vtrn_s8(int8x8_t __a, int8x8_t __b) {
 // FORCE_INLINE uint32x4x2_t vtrnq_u32(uint32x4_t __a, uint32x4_t __b);
 
 FORCE_INLINE int8x8x2_t vzip_s8(int8x8_t __a, int8x8_t __b) {
-  uint16x8_t a_ext =
-      __riscv_vlmul_trunc_v_u16m2_u16m1(__riscv_vzext_vf2_u16m2(__riscv_vreinterpret_v_i8m1_u8m1(__a), 8));
-  uint16x8_t b_ext =
-      __riscv_vlmul_trunc_v_u16m2_u16m1(__riscv_vzext_vf2_u16m2(__riscv_vreinterpret_v_i8m1_u8m1(__b), 8));
-
-  uint16x8_t b_shifted = __riscv_vsll_vx_u16m1(b_ext, 8, 8);
-  uint8x16_t res = __riscv_vreinterpret_v_u16m1_u8m1(__riscv_vor_vv_u16m1(a_ext, b_shifted, 8));
-  uint8x8_t res_low = res;
-  uint8x8_t res_high = __riscv_vslidedown_vx_u8m1(res, 8, 16);
-  return __riscv_vcreate_v_i8m1x2(__riscv_vreinterpret_v_u8m1_i8m1(res_low),
-                                  __riscv_vreinterpret_v_u8m1_i8m1(res_high));
+  // TODO add explaination. source:
+  // https://github.com/riscv-non-isa/rvv-intrinsic-doc/issues/289#issuecomment-1781385001
+  uint8x8_t a_u8 = __riscv_vreinterpret_v_i8m1_u8m1(__a);
+  uint8x8_t b_u8 = __riscv_vreinterpret_v_i8m1_u8m1(__b);
+  vuint16m2_t ab_waddu = __riscv_vwaddu_vv_u16m2(a_u8, b_u8, 8);
+  vuint16m2_t res_m2 = __riscv_vwmaccu_vx_u16m2(ab_waddu, 0xff, b_u8, 8);
+  vint8m1_t res =
+      __riscv_vreinterpret_v_i16m1_i8m1(__riscv_vreinterpret_v_u16m1_i16m1(__riscv_vlmul_trunc_v_u16m2_u16m1(res_m2)));
+  return __riscv_vcreate_v_i8m1x2(res, __riscv_vslidedown_vx_i8m1(res, 8, 16));
 }
 
 // FORCE_INLINE int16x4x2_t vzip_s16(int16x4_t __a, int16x4_t __b);


### PR DESCRIPTION
Optimize vzip with  widening arith, `__riscv_vwmaccu_vx(__riscv_vwaddu_vv(a, b), -1U, b)`

see: https://github.com/riscv-non-isa/rvv-intrinsic-doc/issues/289#issuecomment-1781385001