### PR TITLE
Fix implementations for vlen>128 + additional intrinsics

### DIFF
--- a/neon2rvv.h
+++ b/neon2rvv.h
@@ -11908,7 +11908,7 @@ FORCE_INLINE void vst1_s64(int64_t *a, int64x1_t b) { return __riscv_vse64_v_i64
 
 FORCE_INLINE void vst1_f32(float32_t *a, float32x2_t b) { return __riscv_vse32_v_f32m1(a, b, 2); }
 
-FORCE_INLINE void vst1_u8(uint8_t *a, uint8x8_t b) { return __riscv_vse8_v_u8m1(a, b, 16); }
+FORCE_INLINE void vst1_u8(uint8_t *a, uint8x8_t b) { return __riscv_vse8_v_u8m1(a, b, 8); }
 
 FORCE_INLINE void vst1_u16(uint16_t *a, uint16x4_t b) { return __riscv_vse16_v_u16m1(a, b, 4); }
 

--- a/neon2rvv.h
+++ b/neon2rvv.h
@@ -8042,7 +8042,7 @@ FORCE_INLINE int8x16_t vqtbl2q_s8(int8x16x2_t t, uint8x16_t idx) {
   vint8m1_t table1 = __riscv_vget_v_i8m1x2_i8m1(t, 0);
   vint8m1_t table2 = __riscv_vget_v_i8m1x2_i8m1(t, 1);
   vint8m2_t table = __riscv_vslideup_vx_i8m2(__riscv_vlmul_ext_v_i8m1_i8m2(table1), __riscv_vlmul_ext_v_i8m1_i8m2(table2), 16, 32);
-  vint8m1_t gather = __riscv_vlmul_trunc_v_i8m2_i8m1(__riscv_vrgather_vv_i8m2(table , __riscv_vlmul_ext_v_u8m1_u8m2(idx), 16));
+  vint8m1_t gather = __riscv_vlmul_trunc_v_i8m2_i8m1(__riscv_vrgather_vv_i8m2(table, __riscv_vlmul_ext_v_u8m1_u8m2(idx), 16));
   vbool8_t mask = __riscv_vmsgeu_vx_u8m1_b8(idx, 32, 16);
   return __riscv_vmerge_vxm_i8m1(gather, 0, mask, 16);
 }
@@ -8051,7 +8051,7 @@ FORCE_INLINE uint8x8_t vqtbl2_u8(uint8x16x2_t t, uint8x8_t idx) {
   vuint8m1_t table1 = __riscv_vget_v_u8m1x2_u8m1(t, 0);
   vuint8m1_t table2 = __riscv_vget_v_u8m1x2_u8m1(t, 1);
   vuint8m2_t table = __riscv_vslideup_vx_u8m2(__riscv_vlmul_ext_v_u8m1_u8m2(table1), __riscv_vlmul_ext_v_u8m1_u8m2(table2), 16, 32);
-  vuint8m1_t gather = __riscv_vlmul_trunc_v_u8m2_u8m1(__riscv_vrgather_vv_u8m2(table , __riscv_vlmul_ext_v_u8m1_u8m2(idx), 8));
+  vuint8m1_t gather = __riscv_vlmul_trunc_v_u8m2_u8m1(__riscv_vrgather_vv_u8m2(table, __riscv_vlmul_ext_v_u8m1_u8m2(idx), 8));
   vbool8_t mask = __riscv_vmsgeu_vx_u8m1_b8(idx, 32, 8);
   return __riscv_vmerge_vxm_u8m1(gather, 0, mask, 8);
 }
@@ -8060,7 +8060,7 @@ FORCE_INLINE uint8x16_t vqtbl2q_u8(uint8x16x2_t t, uint8x16_t idx) {
   vuint8m1_t table1 = __riscv_vget_v_u8m1x2_u8m1(t, 0);
   vuint8m1_t table2 = __riscv_vget_v_u8m1x2_u8m1(t, 1);
   vuint8m2_t table = __riscv_vslideup_vx_u8m2(__riscv_vlmul_ext_v_u8m1_u8m2(table1), __riscv_vlmul_ext_v_u8m1_u8m2(table2), 16, 32);
-  vuint8m1_t gather = __riscv_vlmul_trunc_v_u8m2_u8m1(__riscv_vrgather_vv_u8m2(table , __riscv_vlmul_ext_v_u8m1_u8m2(idx), 16));
+  vuint8m1_t gather = __riscv_vlmul_trunc_v_u8m2_u8m1(__riscv_vrgather_vv_u8m2(table, __riscv_vlmul_ext_v_u8m1_u8m2(idx), 16));
   vbool8_t mask = __riscv_vmsgeu_vx_u8m1_b8(idx, 32, 16);
   return __riscv_vmerge_vxm_u8m1(gather, 0, mask, 16);
 }
@@ -9392,7 +9392,7 @@ FORCE_INLINE uint32x4_t vdotq_u32(uint32x4_t r, uint8x16_t a, uint8x16_t b) {
 
 FORCE_INLINE int32x4_t vdotq_laneq_s32(int32x4_t r, int8x16_t a, int8x16_t b, const int lane) {
   vint32m1_t vzero = __riscv_vmv_s_x_i32m1(0, 1);
-  vint8m1_t b_lane = __riscv_vslidedown_vx_i8m1(b, lane*4, 4);
+  vint8m1_t b_lane = __riscv_vslidedown_vx_i8m1(b, lane * 4, 4);
   b_lane = __riscv_vrgather_vv_i8m1(b_lane, __riscv_vand_vx_u8m1(__riscv_vid_v_u8m1(16), 3, 16), 16);
   vint16m2_t ab = __riscv_vwmul_vv_i16m2(b_lane, a, 16);
 
@@ -9412,7 +9412,7 @@ FORCE_INLINE int32x4_t vdotq_laneq_s32(int32x4_t r, int8x16_t a, int8x16_t b, co
 
 FORCE_INLINE int32x4_t vdotq_lane_s32(int32x4_t r, int8x16_t a, int8x8_t b, const int lane) {
   vint32m1_t vzero = __riscv_vmv_s_x_i32m1(0, 1);
-  vint8m1_t b_lane = __riscv_vslidedown_vx_i8m1(b, lane*4, 4);
+  vint8m1_t b_lane = __riscv_vslidedown_vx_i8m1(b, lane * 4, 4);
   b_lane = __riscv_vrgather_vv_i8m1(b_lane, __riscv_vand_vx_u8m1(__riscv_vid_v_u8m1(16), 3, 16), 16);
   vint16m2_t ab = __riscv_vwmul_vv_i16m2(b_lane, a, 16);
 
@@ -9720,7 +9720,7 @@ FORCE_INLINE int32x4_t vusdotq_s32(int32x4_t r, uint8x16_t a, int8x16_t b) {
 
 FORCE_INLINE int32x4_t vusdotq_lane_s32(int32x4_t r, uint8x16_t a, int8x8_t b, const int lane) {
   vint32m1_t vzero = __riscv_vmv_s_x_i32m1(0, 1);
-  vint8m1_t b_lane = __riscv_vslidedown_vx_i8m1(b, lane*4, 4);
+  vint8m1_t b_lane = __riscv_vslidedown_vx_i8m1(b, lane * 4, 4);
   b_lane = __riscv_vrgather_vv_i8m1(b_lane, __riscv_vand_vx_u8m1(__riscv_vid_v_u8m1(16), 3, 16), 16);
   vint16m2_t ab = __riscv_vwmulsu_vv_i16m2(b_lane, a, 16);
 
@@ -9736,7 +9736,7 @@ FORCE_INLINE int32x4_t vusdotq_lane_s32(int32x4_t r, uint8x16_t a, int8x8_t b, c
 
 FORCE_INLINE int32x4_t vusdotq_laneq_s32(int32x4_t r, uint8x16_t a, int8x16_t b, const int lane) {
   vint32m1_t vzero = __riscv_vmv_s_x_i32m1(0, 1);
-  vint8m1_t b_lane = __riscv_vslidedown_vx_i8m1(b, lane*4, 4);
+  vint8m1_t b_lane = __riscv_vslidedown_vx_i8m1(b, lane * 4, 4);
   b_lane = __riscv_vrgather_vv_i8m1(b_lane, __riscv_vand_vx_u8m1(__riscv_vid_v_u8m1(16), 3, 16), 16);
   vint16m2_t ab = __riscv_vwmulsu_vv_i16m2(b_lane, a, 16);
 
@@ -13771,7 +13771,7 @@ FORCE_INLINE void vst1q_f64_x2(float64_t *ptr, float64x2x2_t val) {
 // FORCE_INLINE int8x8x2_t vld1_s8_x2(int8_t const * ptr);
 
 FORCE_INLINE int8x16x2_t vld1q_s8_x2(int8_t const * ptr) {
-  return __riscv_vcreate_v_i8m1x2( __riscv_vle8_v_i8m1(ptr , 16), __riscv_vle8_v_i8m1(ptr + 16 , 16));
+  return __riscv_vcreate_v_i8m1x2( __riscv_vle8_v_i8m1(ptr, 16), __riscv_vle8_v_i8m1(ptr + 16, 16));
 }
 
 // FORCE_INLINE int16x4x2_t vld1_s16_x2(int16_t const * ptr);
@@ -13785,13 +13785,13 @@ FORCE_INLINE int8x16x2_t vld1q_s8_x2(int8_t const * ptr) {
 // FORCE_INLINE uint8x8x2_t vld1_u8_x2(uint8_t const * ptr);
 
 FORCE_INLINE uint8x16x2_t vld1q_u8_x2(uint8_t const * ptr) {
-  return __riscv_vcreate_v_u8m1x2( __riscv_vle8_v_u8m1(ptr , 16), __riscv_vle8_v_u8m1(ptr + 16 , 16));
+  return __riscv_vcreate_v_u8m1x2( __riscv_vle8_v_u8m1(ptr, 16), __riscv_vle8_v_u8m1(ptr + 16, 16));
 }
 
 // FORCE_INLINE uint16x4x2_t vld1_u16_x2(uint16_t const * ptr);
 
 FORCE_INLINE uint16x8x2_t vld1q_u16_x2(uint16_t const * ptr) {
-  return __riscv_vcreate_v_u16m1x2( __riscv_vle16_v_u16m1(ptr , 8), __riscv_vle16_v_u16m1(ptr + 8 , 8));
+  return __riscv_vcreate_v_u16m1x2( __riscv_vle16_v_u16m1(ptr, 8), __riscv_vle16_v_u16m1(ptr + 8, 8));
 }
 
 // FORCE_INLINE uint32x2x2_t vld1_u32_x2(uint32_t const * ptr);
@@ -13845,13 +13845,13 @@ FORCE_INLINE uint16x8x2_t vld1q_u16_x2(uint16_t const * ptr) {
 // FORCE_INLINE uint8x8x3_t vld1_u8_x3(uint8_t const * ptr);
 
 FORCE_INLINE uint8x16x3_t vld1q_u8_x3(uint8_t const * ptr) {
-  return __riscv_vcreate_v_u8m1x3( __riscv_vle8_v_u8m1(ptr , 16), __riscv_vle8_v_u8m1(ptr + 16 , 16), __riscv_vle8_v_u8m1(ptr + 32 , 16));
+  return __riscv_vcreate_v_u8m1x3( __riscv_vle8_v_u8m1(ptr, 16), __riscv_vle8_v_u8m1(ptr + 16, 16), __riscv_vle8_v_u8m1(ptr + 32, 16));
 }
 
 // FORCE_INLINE uint16x4x3_t vld1_u16_x3(uint16_t const * ptr);
 
 FORCE_INLINE uint16x8x3_t vld1q_u16_x3(uint16_t const * ptr) {
-  return __riscv_vcreate_v_u16m1x3( __riscv_vle16_v_u16m1(ptr , 8), __riscv_vle16_v_u16m1(ptr + 8 , 8), __riscv_vle16_v_u16m1(ptr + 16 , 8));
+  return __riscv_vcreate_v_u16m1x3( __riscv_vle16_v_u16m1(ptr, 8), __riscv_vle16_v_u16m1(ptr + 8, 8), __riscv_vle16_v_u16m1(ptr + 16, 8));
 }
 
 // FORCE_INLINE uint32x2x3_t vld1_u32_x3(uint32_t const * ptr);
@@ -13905,13 +13905,13 @@ FORCE_INLINE uint16x8x3_t vld1q_u16_x3(uint16_t const * ptr) {
 // FORCE_INLINE uint8x8x4_t vld1_u8_x4(uint8_t const * ptr);
 
 FORCE_INLINE uint8x16x4_t vld1q_u8_x4(uint8_t const * ptr) {
-  return __riscv_vcreate_v_u8m1x4( __riscv_vle8_v_u8m1(ptr , 16), __riscv_vle8_v_u8m1(ptr + 16 , 16), __riscv_vle8_v_u8m1(ptr + 32 , 16), __riscv_vle8_v_u8m1(ptr + 48 , 16));
+  return __riscv_vcreate_v_u8m1x4( __riscv_vle8_v_u8m1(ptr, 16), __riscv_vle8_v_u8m1(ptr + 16, 16), __riscv_vle8_v_u8m1(ptr + 32, 16), __riscv_vle8_v_u8m1(ptr + 48, 16));
 }
 
 // FORCE_INLINE uint16x4x4_t vld1_u16_x4(uint16_t const * ptr);
 
 FORCE_INLINE uint16x8x4_t vld1q_u16_x4(uint16_t const * ptr) {
-  return __riscv_vcreate_v_u16m1x4( __riscv_vle16_v_u16m1(ptr , 8), __riscv_vle16_v_u16m1(ptr + 8 , 8), __riscv_vle16_v_u16m1(ptr + 16 , 8), __riscv_vle16_v_u16m1(ptr + 24 , 8));
+  return __riscv_vcreate_v_u16m1x4( __riscv_vle16_v_u16m1(ptr, 8), __riscv_vle16_v_u16m1(ptr + 8, 8), __riscv_vle16_v_u16m1(ptr + 16, 8), __riscv_vle16_v_u16m1(ptr + 24, 8));
 }
 
 // FORCE_INLINE uint32x2x4_t vld1_u32_x4(uint32_t const * ptr);

--- a/neon2rvv.h
+++ b/neon2rvv.h
@@ -4384,29 +4384,53 @@ FORCE_INLINE float64_t vaddvq_f64(float64x2_t a) {
   return __riscv_vfmv_f_s_f64m1_f64(__riscv_vfredosum_vs_f64m1_f64m1(a, __riscv_vfmv_v_f_f64m1(0, 2), 2));
 }
 
-// FORCE_INLINE int16_t vaddlv_s8(int8x8_t a);
+FORCE_INLINE int16_t vaddlv_s8(int8x8_t a) {
+  return __riscv_vmv_x_s_i16m1_i16(__riscv_vwredsum_vs_i8m1_i16m1(a, vdup_n_s16(0), 8));
+}
 
-// FORCE_INLINE int16_t vaddlvq_s8(int8x16_t a);
+FORCE_INLINE int16_t vaddlvq_s8(int8x16_t a) {
+  return __riscv_vmv_x_s_i16m1_i16(__riscv_vwredsum_vs_i8m1_i16m1(a, vdupq_n_s16(0), 16));
+}
 
-// FORCE_INLINE int32_t vaddlv_s16(int16x4_t a);
+FORCE_INLINE int32_t vaddlv_s16(int16x4_t a) {
+  return __riscv_vmv_x_s_i32m1_i32(__riscv_vwredsum_vs_i16m1_i32m1(a, vdup_n_s32(0), 4));
+}
 
-// FORCE_INLINE int32_t vaddlvq_s16(int16x8_t a);
+FORCE_INLINE int32_t vaddlvq_s16(int16x8_t a) {
+  return __riscv_vmv_x_s_i32m1_i32(__riscv_vwredsum_vs_i16m1_i32m1(a, vdupq_n_s32(0), 8));
+}
 
-// FORCE_INLINE int64_t vaddlv_s32(int32x2_t a);
+FORCE_INLINE int64_t vaddlv_s32(int32x2_t a) {
+  return __riscv_vmv_x_s_i64m1_i64(__riscv_vwredsum_vs_i32m1_i64m1(a, vdup_n_s64(0), 2));
+};
 
-// FORCE_INLINE int64_t vaddlvq_s32(int32x4_t a);
+FORCE_INLINE int64_t vaddlvq_s32(int32x4_t a) {
+  return __riscv_vmv_x_s_i64m1_i64(__riscv_vwredsum_vs_i32m1_i64m1(a, vdupq_n_s64(0), 4));
+};
 
-// FORCE_INLINE uint16_t vaddlv_u8(uint8x8_t a);
+FORCE_INLINE uint16_t vaddlv_u8(uint8x8_t a) {
+  return __riscv_vmv_x_s_u16m1_u16(__riscv_vwredsumu_vs_u8m1_u16m1(a, vdup_n_u16(0), 8));
+}
 
-// FORCE_INLINE uint16_t vaddlvq_u8(uint8x16_t a);
+FORCE_INLINE uint16_t vaddlvq_u8(uint8x16_t a) {
+  return __riscv_vmv_x_s_u16m1_u16(__riscv_vwredsumu_vs_u8m1_u16m1(a, vdupq_n_u16(0), 16));
+}
 
-// FORCE_INLINE uint32_t vaddlv_u16(uint16x4_t a);
+FORCE_INLINE uint32_t vaddlv_u16(uint16x4_t a) {
+  return __riscv_vmv_x_s_u32m1_u32(__riscv_vwredsumu_vs_u16m1_u32m1(a, vdup_n_u32(0), 4));
+}
 
-// FORCE_INLINE uint32_t vaddlvq_u16(uint16x8_t a);
+FORCE_INLINE uint32_t vaddlvq_u16(uint16x8_t a) {
+  return __riscv_vmv_x_s_u32m1_u32(__riscv_vwredsumu_vs_u16m1_u32m1(a, vdupq_n_u32(0), 8));
+}
 
-// FORCE_INLINE uint64_t vaddlv_u32(uint32x2_t a);
+FORCE_INLINE uint64_t vaddlv_u32(uint32x2_t a) {
+  return __riscv_vmv_x_s_u64m1_u64(__riscv_vwredsumu_vs_u32m1_u64m1(a, vdup_n_u64(0), 2));
+}
 
-// FORCE_INLINE uint64_t vaddlvq_u32(uint32x4_t a);
+FORCE_INLINE uint64_t vaddlvq_u32(uint32x4_t a) {
+  return __riscv_vmv_x_s_u64m1_u64(__riscv_vwredsumu_vs_u32m1_u64m1(a, vdupq_n_u64(0), 4));
+}
 
 FORCE_INLINE int8_t vmaxv_s8(int8x8_t a) {
   return __riscv_vmv_x_s_i8m1_i8(__riscv_vredmax_vs_i8m1_i8m1(a, vdup_n_s8(INT8_MIN), 8));
@@ -7786,13 +7810,13 @@ FORCE_INLINE uint64x2_t vmovl_high_u32(uint32x4_t a) {
 }
 
 FORCE_INLINE int8x8_t vtbl1_s8(int8x8_t a, int8x8_t b) {
-  vint8m1_t a_s = __riscv_vslideup_vx_i8m1(a, vdup_n_s8(0), 8, 16);
-  return __riscv_vrgather_vv_i8m1(a_s, __riscv_vreinterpret_v_i8m1_u8m1(b), 8);
+  vbool8_t mask = __riscv_vmsge_vx_i8m1_b8(b, 8, 8);
+  return __riscv_vmerge_vxm_i8m1(__riscv_vrgather_vv_i8m1(a, __riscv_vreinterpret_v_i8m1_u8m1(b), 8), 0, mask, 8);
 }
 
 FORCE_INLINE uint8x8_t vtbl1_u8(uint8x8_t a, uint8x8_t b) {
-  vuint8m1_t a_s = __riscv_vslideup_vx_u8m1(a, vdup_n_u8(0), 8, 16);
-  return __riscv_vrgather_vv_u8m1(a_s, b, 8);
+  vbool8_t mask = __riscv_vmsgeu_vx_u8m1_b8(b, 8, 8);
+  return __riscv_vmerge_vxm_u8m1(__riscv_vrgather_vv_u8m1(a, b, 8), 0, mask, 8);
 }
 
 // FORCE_INLINE poly8x8_t vtbl1_p8(poly8x8_t a, uint8x8_t idx);
@@ -7801,14 +7825,16 @@ FORCE_INLINE int8x8_t vtbl2_s8(int8x8x2_t a, int8x8_t b) {
   vint8m1_t table1 = __riscv_vget_v_i8m1x2_i8m1(a, 0);
   vint8m1_t table2 = __riscv_vget_v_i8m1x2_i8m1(a, 1);
   vint8m1_t table = __riscv_vslideup_vx_i8m1(table1, table2, 8, 16);
-  return __riscv_vrgather_vv_i8m1(table, __riscv_vreinterpret_v_i8m1_u8m1(b), 8);
+  vbool8_t mask = __riscv_vmsge_vx_i8m1_b8(b, 16, 8);
+  return __riscv_vmerge_vxm_i8m1(__riscv_vrgather_vv_i8m1(table, __riscv_vreinterpret_v_i8m1_u8m1(b), 8), 0, mask, 8);
 }
 
 FORCE_INLINE uint8x8_t vtbl2_u8(uint8x8x2_t a, uint8x8_t b) {
   vuint8m1_t table1 = __riscv_vget_v_u8m1x2_u8m1(a, 0);
   vuint8m1_t table2 = __riscv_vget_v_u8m1x2_u8m1(a, 1);
   vuint8m1_t table = __riscv_vslideup_vx_u8m1(table1, table2, 8, 16);
-  return __riscv_vrgather_vv_u8m1(table, b, 8);
+  vbool8_t mask = __riscv_vmsgeu_vx_u8m1_b8(b, 16, 8);
+  return __riscv_vmerge_vxm_u8m1(__riscv_vrgather_vv_u8m1(table, b, 8), 0, mask, 8);
 }
 
 // FORCE_INLINE poly8x8_t vtbl2_p8(poly8x8x2_t a, uint8x8_t idx);
@@ -7820,8 +7846,10 @@ FORCE_INLINE int8x8_t vtbl3_s8(int8x8x3_t a, int8x8_t b) {
   vint8m2_t table12 = __riscv_vlmul_ext_v_i8m1_i8m2(__riscv_vslideup_vx_i8m1(table1, table2, 8, 16));
   vint8m2_t table34 = __riscv_vlmul_ext_v_i8m1_i8m2(__riscv_vslideup_vx_i8m1(table3, vdup_n_s8(0), 8, 16));
   vint8m2_t table = __riscv_vslideup_vx_i8m2(table12, table34, 16, 32);
-  return __riscv_vlmul_trunc_v_i8m2_i8m1(
+  vint8m1_t gather = __riscv_vlmul_trunc_v_i8m2_i8m1(
       __riscv_vrgather_vv_i8m2(table, __riscv_vlmul_ext_v_u8m1_u8m2(__riscv_vreinterpret_v_i8m1_u8m1(b)), 8));
+  vbool8_t mask = __riscv_vmsge_vx_i8m1_b8(b, 24, 8);
+  return __riscv_vmerge_vxm_i8m1(gather, 0, mask, 8);
 }
 
 FORCE_INLINE uint8x8_t vtbl3_u8(uint8x8x3_t a, uint8x8_t b) {
@@ -7831,7 +7859,9 @@ FORCE_INLINE uint8x8_t vtbl3_u8(uint8x8x3_t a, uint8x8_t b) {
   vuint8m2_t table12 = __riscv_vlmul_ext_v_u8m1_u8m2(__riscv_vslideup_vx_u8m1(table1, table2, 8, 16));
   vuint8m2_t table34 = __riscv_vlmul_ext_v_u8m1_u8m2(__riscv_vslideup_vx_u8m1(table3, vdup_n_u8(0), 8, 16));
   vuint8m2_t table = __riscv_vslideup_vx_u8m2(table12, table34, 16, 32);
-  return __riscv_vlmul_trunc_v_u8m2_u8m1(__riscv_vrgather_vv_u8m2(table, __riscv_vlmul_ext_v_u8m1_u8m2(b), 8));
+  vuint8m1_t gather = __riscv_vlmul_trunc_v_u8m2_u8m1(__riscv_vrgather_vv_u8m2(table, __riscv_vlmul_ext_v_u8m1_u8m2(b), 8));
+  vbool8_t mask = __riscv_vmsgeu_vx_u8m1_b8(b, 24, 8);
+  return __riscv_vmerge_vxm_u8m1(gather, 0, mask, 8);
 }
 
 // FORCE_INLINE poly8x8_t vtbl3_p8(poly8x8x3_t a, uint8x8_t idx);
@@ -7844,8 +7874,10 @@ FORCE_INLINE int8x8_t vtbl4_s8(int8x8x4_t a, int8x8_t b) {
   vint8m2_t table12 = __riscv_vlmul_ext_v_i8m1_i8m2(__riscv_vslideup_vx_i8m1(table1, table2, 8, 16));
   vint8m2_t table34 = __riscv_vlmul_ext_v_i8m1_i8m2(__riscv_vslideup_vx_i8m1(table3, table4, 8, 16));
   vint8m2_t table = __riscv_vslideup_vx_i8m2(table12, table34, 16, 32);
-  return __riscv_vlmul_trunc_v_i8m2_i8m1(
+  vint8m1_t gather = __riscv_vlmul_trunc_v_i8m2_i8m1(
       __riscv_vrgather_vv_i8m2(table, __riscv_vlmul_ext_v_u8m1_u8m2(__riscv_vreinterpret_v_i8m1_u8m1(b)), 8));
+  vbool8_t mask = __riscv_vmsge_vx_i8m1_b8(b, 32, 8);
+  return __riscv_vmerge_vxm_i8m1(gather, 0, mask, 8);
 }
 
 FORCE_INLINE uint8x8_t vtbl4_u8(uint8x8x4_t a, uint8x8_t b) {
@@ -7856,7 +7888,9 @@ FORCE_INLINE uint8x8_t vtbl4_u8(uint8x8x4_t a, uint8x8_t b) {
   vuint8m2_t table12 = __riscv_vlmul_ext_v_u8m1_u8m2(__riscv_vslideup_vx_u8m1(table1, table2, 8, 16));
   vuint8m2_t table34 = __riscv_vlmul_ext_v_u8m1_u8m2(__riscv_vslideup_vx_u8m1(table3, table4, 8, 16));
   vuint8m2_t table = __riscv_vslideup_vx_u8m2(table12, table34, 16, 32);
-  return __riscv_vlmul_trunc_v_u8m2_u8m1(__riscv_vrgather_vv_u8m2(table, __riscv_vlmul_ext_v_u8m1_u8m2(b), 8));
+  vuint8m1_t gather = __riscv_vlmul_trunc_v_u8m2_u8m1(__riscv_vrgather_vv_u8m2(table, __riscv_vlmul_ext_v_u8m1_u8m2(b), 8));
+  vbool8_t mask = __riscv_vmsgeu_vx_u8m1_b8(b, 32, 8);
+  return __riscv_vmerge_vxm_u8m1(gather, 0, mask, 8);
 }
 
 // FORCE_INLINE poly8x8_t vtbl4_p8(poly8x8x4_t a, uint8x8_t idx);
@@ -7971,11 +8005,20 @@ FORCE_INLINE uint8x8_t vtbx4_u8(uint8x8_t a, uint8x8x4_t b, uint8x8_t c) {
 
 // FORCE_INLINE int8x8_t vqtbl1_s8(int8x16_t t, uint8x8_t idx);
 
-// FORCE_INLINE int8x16_t vqtbl1q_s8(int8x16_t t, uint8x16_t idx);
+FORCE_INLINE int8x16_t vqtbl1q_s8(int8x16_t t, uint8x16_t idx) {
+  vbool8_t mask = __riscv_vmsgeu_vx_u8m1_b8(idx, 16, 16);
+  return __riscv_vmerge_vxm_i8m1(__riscv_vrgather_vv_i8m1(t, idx, 16), 0, mask, 16);
+}
 
-// FORCE_INLINE uint8x8_t vqtbl1_u8(uint8x16_t t, uint8x8_t idx);
+FORCE_INLINE uint8x8_t vqtbl1_u8(uint8x16_t t, uint8x8_t idx) {
+  vbool8_t mask = __riscv_vmsgeu_vx_u8m1_b8(idx, 16, 8);
+  return __riscv_vmerge_vxm_u8m1(__riscv_vrgather_vv_u8m1(t, idx, 16), 0, mask, 8);
+}
 
-// FORCE_INLINE uint8x16_t vqtbl1q_u8(uint8x16_t t, uint8x16_t idx);
+FORCE_INLINE uint8x16_t vqtbl1q_u8(uint8x16_t t, uint8x16_t idx) {
+  vbool8_t mask = __riscv_vmsgeu_vx_u8m1_b8(idx, 16, 16);
+  return __riscv_vmerge_vxm_u8m1(__riscv_vrgather_vv_u8m1(t, idx, 16), 0, mask, 16);
+}
 
 // FORCE_INLINE poly8x8_t vqtbl1_p8(poly8x16_t t, uint8x8_t idx);
 
@@ -7995,11 +8038,32 @@ FORCE_INLINE uint8x8_t vtbx4_u8(uint8x8_t a, uint8x8x4_t b, uint8x8_t c) {
 
 // FORCE_INLINE int8x8_t vqtbl2_s8(int8x16x2_t t, uint8x8_t idx);
 
-// FORCE_INLINE int8x16_t vqtbl2q_s8(int8x16x2_t t, uint8x16_t idx);
+FORCE_INLINE int8x16_t vqtbl2q_s8(int8x16x2_t t, uint8x16_t idx) {
+  vint8m1_t table1 = __riscv_vget_v_i8m1x2_i8m1(t, 0);
+  vint8m1_t table2 = __riscv_vget_v_i8m1x2_i8m1(t, 1);
+  vint8m2_t table = __riscv_vslideup_vx_i8m2(__riscv_vlmul_ext_v_i8m1_i8m2(table1), __riscv_vlmul_ext_v_i8m1_i8m2(table2), 16, 32);
+  vint8m1_t gather = __riscv_vlmul_trunc_v_i8m2_i8m1(__riscv_vrgather_vv_i8m2(table , __riscv_vlmul_ext_v_u8m1_u8m2(idx), 16));
+  vbool8_t mask = __riscv_vmsgeu_vx_u8m1_b8(idx, 32, 16);
+  return __riscv_vmerge_vxm_i8m1(gather, 0, mask, 16);
+}
 
-// FORCE_INLINE uint8x8_t vqtbl2_u8(uint8x16x2_t t, uint8x8_t idx);
+FORCE_INLINE uint8x8_t vqtbl2_u8(uint8x16x2_t t, uint8x8_t idx) {
+  vuint8m1_t table1 = __riscv_vget_v_u8m1x2_u8m1(t, 0);
+  vuint8m1_t table2 = __riscv_vget_v_u8m1x2_u8m1(t, 1);
+  vuint8m2_t table = __riscv_vslideup_vx_u8m2(__riscv_vlmul_ext_v_u8m1_u8m2(table1), __riscv_vlmul_ext_v_u8m1_u8m2(table2), 16, 32);
+  vuint8m1_t gather = __riscv_vlmul_trunc_v_u8m2_u8m1(__riscv_vrgather_vv_u8m2(table , __riscv_vlmul_ext_v_u8m1_u8m2(idx), 8));
+  vbool8_t mask = __riscv_vmsgeu_vx_u8m1_b8(idx, 32, 8);
+  return __riscv_vmerge_vxm_u8m1(gather, 0, mask, 8);
+}
 
-// FORCE_INLINE uint8x16_t vqtbl2q_u8(uint8x16x2_t t, uint8x16_t idx);
+FORCE_INLINE uint8x16_t vqtbl2q_u8(uint8x16x2_t t, uint8x16_t idx) {
+  vuint8m1_t table1 = __riscv_vget_v_u8m1x2_u8m1(t, 0);
+  vuint8m1_t table2 = __riscv_vget_v_u8m1x2_u8m1(t, 1);
+  vuint8m2_t table = __riscv_vslideup_vx_u8m2(__riscv_vlmul_ext_v_u8m1_u8m2(table1), __riscv_vlmul_ext_v_u8m1_u8m2(table2), 16, 32);
+  vuint8m1_t gather = __riscv_vlmul_trunc_v_u8m2_u8m1(__riscv_vrgather_vv_u8m2(table , __riscv_vlmul_ext_v_u8m1_u8m2(idx), 16));
+  vbool8_t mask = __riscv_vmsgeu_vx_u8m1_b8(idx, 32, 16);
+  return __riscv_vmerge_vxm_u8m1(gather, 0, mask, 16);
+}
 
 // FORCE_INLINE poly8x8_t vqtbl2_p8(poly8x16x2_t t, uint8x8_t idx);
 
@@ -8011,7 +8075,19 @@ FORCE_INLINE uint8x8_t vtbx4_u8(uint8x8_t a, uint8x8x4_t b, uint8x8_t c) {
 
 // FORCE_INLINE uint8x8_t vqtbl3_u8(uint8x16x3_t t, uint8x8_t idx);
 
-// FORCE_INLINE uint8x16_t vqtbl3q_u8(uint8x16x3_t t, uint8x16_t idx);
+FORCE_INLINE uint8x16_t vqtbl3q_u8(uint8x16x3_t t, uint8x16_t idx) {
+  vuint8m4_t table1 = __riscv_vlmul_ext_v_u8m1_u8m4(__riscv_vget_v_u8m1x3_u8m1(t, 0));
+  vuint8m4_t table2 = __riscv_vlmul_ext_v_u8m1_u8m4(__riscv_vget_v_u8m1x3_u8m1(t, 1));
+  vuint8m4_t table3 = __riscv_vlmul_ext_v_u8m1_u8m4(__riscv_vget_v_u8m1x3_u8m1(t, 2));
+
+  vuint8m4_t table12 = __riscv_vslideup_vx_u8m4(table1, table2, 16, 32);
+  vuint8m4_t table30 = __riscv_vslideup_vx_u8m4(table3, __riscv_vlmul_ext_v_u8m1_u8m4(vdupq_n_u8(0)), 16, 32);
+
+  vuint8m4_t table = __riscv_vslideup_vx_u8m4(table12, table30, 32, 64);
+  vuint8m1_t gather = __riscv_vlmul_trunc_v_u8m4_u8m1(__riscv_vrgather_vv_u8m4(table, __riscv_vlmul_ext_v_u8m1_u8m4(idx), 16));
+  vbool8_t mask = __riscv_vmsgeu_vx_u8m1_b8(idx, 48, 16);
+  return __riscv_vmerge_vxm_u8m1(gather, 0, mask, 16);
+}
 
 // FORCE_INLINE poly8x8_t vqtbl3_p8(poly8x16x3_t t, uint8x8_t idx);
 
@@ -8023,7 +8099,20 @@ FORCE_INLINE uint8x8_t vtbx4_u8(uint8x8_t a, uint8x8x4_t b, uint8x8_t c) {
 
 // FORCE_INLINE uint8x8_t vqtbl4_u8(uint8x16x4_t t, uint8x8_t idx);
 
-// FORCE_INLINE uint8x16_t vqtbl4q_u8(uint8x16x4_t t, uint8x16_t idx);
+FORCE_INLINE uint8x16_t vqtbl4q_u8(uint8x16x4_t t, uint8x16_t idx) {
+  vuint8m4_t table1 = __riscv_vlmul_ext_v_u8m1_u8m4(__riscv_vget_v_u8m1x4_u8m1(t, 0));
+  vuint8m4_t table2 = __riscv_vlmul_ext_v_u8m1_u8m4(__riscv_vget_v_u8m1x4_u8m1(t, 1));
+  vuint8m4_t table3 = __riscv_vlmul_ext_v_u8m1_u8m4(__riscv_vget_v_u8m1x4_u8m1(t, 2));
+  vuint8m4_t table4 = __riscv_vlmul_ext_v_u8m1_u8m4(__riscv_vget_v_u8m1x4_u8m1(t, 3));
+
+  vuint8m4_t table12 = __riscv_vslideup_vx_u8m4(table1, table2, 16, 32);
+  vuint8m4_t table34 = __riscv_vslideup_vx_u8m4(table3, table4, 16, 32);
+
+  vuint8m4_t table = __riscv_vslideup_vx_u8m4(table12, table34, 32, 64);
+  vuint8m1_t gather = __riscv_vlmul_trunc_v_u8m4_u8m1(__riscv_vrgather_vv_u8m4(table, __riscv_vlmul_ext_v_u8m1_u8m4(idx), 16));
+  vbool8_t mask = __riscv_vmsgeu_vx_u8m1_b8(idx, 64, 16);
+  return __riscv_vmerge_vxm_u8m1(gather, 0, mask, 16);
+}
 
 // FORCE_INLINE poly8x8_t vqtbl4_p8(poly8x16x4_t t, uint8x8_t idx);
 
@@ -9269,11 +9358,29 @@ FORCE_INLINE int32x4_t vqrdmlshq_lane_s32(int32x4_t a, int32x4_t b, int32x2_t c,
 
 // FORCE_INLINE float16_t vduph_laneq_f16(float16x8_t vec, const int lane);
 
-// FORCE_INLINE uint32x2_t vdot_u32(uint32x2_t r, uint8x8_t a, uint8x8_t b);
+FORCE_INLINE uint32x2_t vdot_u32(uint32x2_t r, uint8x8_t a, uint8x8_t b) {
+  vuint32m1_t vzero = __riscv_vmv_s_x_u32m1(0, 1);
+  vuint16m1_t ab = __riscv_vlmul_trunc_v_u16m2_u16m1(__riscv_vwmulu_vv_u16m2(a, b, 8));
+  vbool16_t mask = __riscv_vmsleu_vx_u16m1_b16(__riscv_vid_v_u16m1(8), 3, 8);
+
+  vuint32m1_t r0 = __riscv_vwredsumu_vs_u16m1_u32m1_m(mask, ab, vzero, 8);
+  vuint32m1_t r1 = __riscv_vwredsumu_vs_u16m1_u32m1_m(__riscv_vmnot_m_b16(mask, 8), ab, vzero, 8);
+  return __riscv_vadd_vv_u32m1(r, __riscv_vslideup_vx_u32m1(r0, r1, 1, 2), 2);
+}
 
 // FORCE_INLINE int32x2_t vdot_s32(int32x2_t r, int8x8_t a, int8x8_t b);
 
-// FORCE_INLINE uint32x4_t vdotq_u32(uint32x4_t r, uint8x16_t a, uint8x16_t b);
+FORCE_INLINE uint32x4_t vdotq_u32(uint32x4_t r, uint8x16_t a, uint8x16_t b) {
+  vuint32m1_t vzero = __riscv_vmv_s_x_u32m1(0, 1);
+  vuint16m2_t ab = __riscv_vwmulu_vv_u16m2(a, b, 16);
+
+  vuint32m1_t r0 = __riscv_vwredsumu_vs_u16m2_u32m1(ab, vzero, 4);
+  vuint32m1_t r1 = __riscv_vwredsumu_vs_u16m2_u32m1(__riscv_vslidedown_vx_u16m2(ab, 4, 4), vzero, 4);
+  vuint32m1_t r2 = __riscv_vwredsumu_vs_u16m2_u32m1(__riscv_vslidedown_vx_u16m2(ab, 8, 4), vzero, 4);
+  vuint32m1_t r3 = __riscv_vwredsumu_vs_u16m2_u32m1(__riscv_vslidedown_vx_u16m2(ab, 12, 4), vzero, 4);
+
+  return __riscv_vadd_vv_u32m1(r, __riscv_vslideup_vx_u32m1(__riscv_vslideup_vx_u32m1(r0, r1, 1, 2), __riscv_vslideup_vx_u32m1(r2, r3, 1, 2), 2, 4), 4);
+}
 
 // FORCE_INLINE int32x4_t vdotq_s32(int32x4_t r, int8x16_t a, int8x16_t b);
 
@@ -9283,7 +9390,19 @@ FORCE_INLINE int32x4_t vqrdmlshq_lane_s32(int32x4_t a, int32x4_t b, int32x2_t c,
 
 // FORCE_INLINE uint32x4_t vdotq_laneq_u32(uint32x4_t r, uint8x16_t a, uint8x16_t b, const int lane);
 
-// FORCE_INLINE int32x4_t vdotq_laneq_s32(int32x4_t r, int8x16_t a, int8x16_t b, const int lane);
+FORCE_INLINE int32x4_t vdotq_laneq_s32(int32x4_t r, int8x16_t a, int8x16_t b, const int lane) {
+  vint32m1_t vzero = __riscv_vmv_s_x_i32m1(0, 1);
+  vint8m1_t b_lane = __riscv_vslidedown_vx_i8m1(b, lane*4, 4);
+  b_lane = __riscv_vrgather_vv_i8m1(b_lane, __riscv_vand_vx_u8m1(__riscv_vid_v_u8m1(16), 3, 16), 16);
+  vint16m2_t ab = __riscv_vwmul_vv_i16m2(b_lane, a, 16);
+
+  vint32m1_t r0 = __riscv_vwredsum_vs_i16m2_i32m1(ab, vzero, 4);
+  vint32m1_t r1 = __riscv_vwredsum_vs_i16m2_i32m1(__riscv_vslidedown_vx_i16m2(ab, 4, 4), vzero, 4);
+  vint32m1_t r2 = __riscv_vwredsum_vs_i16m2_i32m1(__riscv_vslidedown_vx_i16m2(ab, 8, 4), vzero, 4);
+  vint32m1_t r3 = __riscv_vwredsum_vs_i16m2_i32m1(__riscv_vslidedown_vx_i16m2(ab, 12, 4), vzero, 4);
+
+  return __riscv_vadd_vv_i32m1(r, __riscv_vslideup_vx_i32m1(__riscv_vslideup_vx_i32m1(r0, r1, 1, 2), __riscv_vslideup_vx_i32m1(r2, r3, 1, 2), 2, 4), 4);
+}
 
 // FORCE_INLINE uint32x2_t vdot_laneq_u32(uint32x2_t r, uint8x8_t a, uint8x16_t b, const int lane);
 
@@ -9291,7 +9410,19 @@ FORCE_INLINE int32x4_t vqrdmlshq_lane_s32(int32x4_t a, int32x4_t b, int32x2_t c,
 
 // FORCE_INLINE uint32x4_t vdotq_lane_u32(uint32x4_t r, uint8x16_t a, uint8x8_t b, const int lane);
 
-// FORCE_INLINE int32x4_t vdotq_lane_s32(int32x4_t r, int8x16_t a, int8x8_t b, const int lane);
+FORCE_INLINE int32x4_t vdotq_lane_s32(int32x4_t r, int8x16_t a, int8x8_t b, const int lane) {
+  vint32m1_t vzero = __riscv_vmv_s_x_i32m1(0, 1);
+  vint8m1_t b_lane = __riscv_vslidedown_vx_i8m1(b, lane*4, 4);
+  b_lane = __riscv_vrgather_vv_i8m1(b_lane, __riscv_vand_vx_u8m1(__riscv_vid_v_u8m1(16), 3, 16), 16);
+  vint16m2_t ab = __riscv_vwmul_vv_i16m2(b_lane, a, 16);
+
+  vint32m1_t r0 = __riscv_vwredsum_vs_i16m2_i32m1(ab, vzero, 4);
+  vint32m1_t r1 = __riscv_vwredsum_vs_i16m2_i32m1(__riscv_vslidedown_vx_i16m2(ab, 4, 4), vzero, 4);
+  vint32m1_t r2 = __riscv_vwredsum_vs_i16m2_i32m1(__riscv_vslidedown_vx_i16m2(ab, 8, 4), vzero, 4);
+  vint32m1_t r3 = __riscv_vwredsum_vs_i16m2_i32m1(__riscv_vslidedown_vx_i16m2(ab, 12, 4), vzero, 4);
+
+  return __riscv_vadd_vv_i32m1(r, __riscv_vslideup_vx_i32m1(__riscv_vslideup_vx_i32m1(r0, r1, 1, 2), __riscv_vslideup_vx_i32m1(r2, r3, 1, 2), 2, 4), 4);
+}
 
 // FORCE_INLINE uint64x2_t vsha512hq_u64(uint64x2_t hash_ed, uint64x2_t hash_gf, uint64x2_t kwh_kwh2);
 
@@ -9575,13 +9706,47 @@ FORCE_INLINE int32x4_t vqrdmlshq_lane_s32(int32x4_t a, int32x4_t b, int32x2_t c,
 
 // FORCE_INLINE int32x2_t vsudot_laneq_s32(int32x2_t r, int8x8_t a, uint8x16_t b, const int lane);
 
-// FORCE_INLINE int32x4_t vusdotq_s32(int32x4_t r, uint8x16_t a, int8x16_t b);
+FORCE_INLINE int32x4_t vusdotq_s32(int32x4_t r, uint8x16_t a, int8x16_t b) {
+  vint32m1_t vzero = __riscv_vmv_s_x_i32m1(0, 1);
+  vint16m2_t ab = __riscv_vwmulsu_vv_i16m2(b, a, 16);
 
-// FORCE_INLINE int32x4_t vusdotq_lane_s32(int32x4_t r, uint8x16_t a, int8x8_t b, const int lane);
+  vint32m1_t r0 = __riscv_vwredsum_vs_i16m2_i32m1(ab, vzero, 4);
+  vint32m1_t r1 = __riscv_vwredsum_vs_i16m2_i32m1(__riscv_vslidedown_vx_i16m2(ab, 4, 4), vzero, 4);
+  vint32m1_t r2 = __riscv_vwredsum_vs_i16m2_i32m1(__riscv_vslidedown_vx_i16m2(ab, 8, 4), vzero, 4);
+  vint32m1_t r3 = __riscv_vwredsum_vs_i16m2_i32m1(__riscv_vslidedown_vx_i16m2(ab, 12, 4), vzero, 4);
+
+  return __riscv_vadd_vv_i32m1(r, __riscv_vslideup_vx_i32m1(__riscv_vslideup_vx_i32m1(r0, r1, 1, 2), __riscv_vslideup_vx_i32m1(r2, r3, 1, 2), 2, 4), 4);
+}
+
+FORCE_INLINE int32x4_t vusdotq_lane_s32(int32x4_t r, uint8x16_t a, int8x8_t b, const int lane) {
+  vint32m1_t vzero = __riscv_vmv_s_x_i32m1(0, 1);
+  vint8m1_t b_lane = __riscv_vslidedown_vx_i8m1(b, lane*4, 4);
+  b_lane = __riscv_vrgather_vv_i8m1(b_lane, __riscv_vand_vx_u8m1(__riscv_vid_v_u8m1(16), 3, 16), 16);
+  vint16m2_t ab = __riscv_vwmulsu_vv_i16m2(b_lane, a, 16);
+
+  vint32m1_t r0 = __riscv_vwredsum_vs_i16m2_i32m1(ab, vzero, 4);
+  vint32m1_t r1 = __riscv_vwredsum_vs_i16m2_i32m1(__riscv_vslidedown_vx_i16m2(ab, 4, 4), vzero, 4);
+  vint32m1_t r2 = __riscv_vwredsum_vs_i16m2_i32m1(__riscv_vslidedown_vx_i16m2(ab, 8, 4), vzero, 4);
+  vint32m1_t r3 = __riscv_vwredsum_vs_i16m2_i32m1(__riscv_vslidedown_vx_i16m2(ab, 12, 4), vzero, 4);
+
+  return __riscv_vadd_vv_i32m1(r, __riscv_vslideup_vx_i32m1(__riscv_vslideup_vx_i32m1(r0, r1, 1, 2), __riscv_vslideup_vx_i32m1(r2, r3, 1, 2), 2, 4), 4);
+}
 
 // FORCE_INLINE int32x4_t vsudotq_lane_s32(int32x4_t r, int8x16_t a, uint8x8_t b, const int lane);
 
-// FORCE_INLINE int32x4_t vusdotq_laneq_s32(int32x4_t r, uint8x16_t a, int8x16_t b, const int lane);
+FORCE_INLINE int32x4_t vusdotq_laneq_s32(int32x4_t r, uint8x16_t a, int8x16_t b, const int lane) {
+  vint32m1_t vzero = __riscv_vmv_s_x_i32m1(0, 1);
+  vint8m1_t b_lane = __riscv_vslidedown_vx_i8m1(b, lane*4, 4);
+  b_lane = __riscv_vrgather_vv_i8m1(b_lane, __riscv_vand_vx_u8m1(__riscv_vid_v_u8m1(16), 3, 16), 16);
+  vint16m2_t ab = __riscv_vwmulsu_vv_i16m2(b_lane, a, 16);
+
+  vint32m1_t r0 = __riscv_vwredsum_vs_i16m2_i32m1(ab, vzero, 4);
+  vint32m1_t r1 = __riscv_vwredsum_vs_i16m2_i32m1(__riscv_vslidedown_vx_i16m2(ab, 4, 4), vzero, 4);
+  vint32m1_t r2 = __riscv_vwredsum_vs_i16m2_i32m1(__riscv_vslidedown_vx_i16m2(ab, 8, 4), vzero, 4);
+  vint32m1_t r3 = __riscv_vwredsum_vs_i16m2_i32m1(__riscv_vslidedown_vx_i16m2(ab, 12, 4), vzero, 4);
+
+  return __riscv_vadd_vv_i32m1(r, __riscv_vslideup_vx_i32m1(__riscv_vslideup_vx_i32m1(r0, r1, 1, 2), __riscv_vslideup_vx_i32m1(r2, r3, 1, 2), 2, 4), 4);
+}
 
 // FORCE_INLINE int32x4_t vsudotq_laneq_s32(int32x4_t r, int8x16_t a, uint8x16_t b, const int lane);
 
@@ -10502,13 +10667,29 @@ FORCE_INLINE uint8x16_t vrev16q_u8(uint8x16_t a) {
 
 // FORCE_INLINE int16x4_t vzip1_s16(int16x4_t a, int16x4_t b);
 
-// FORCE_INLINE int16x8_t vzip1q_s16(int16x8_t a, int16x8_t b);
+FORCE_INLINE int16x8_t vzip1q_s16(int16x8_t a, int16x8_t b) {
+  vuint16m1_t a_u16 = __riscv_vreinterpret_v_i16m1_u16m1(a);
+  vuint16m1_t b_u16 = __riscv_vreinterpret_v_i16m1_u16m1(b);
+  vuint32m2_t ab_waddu = __riscv_vwaddu_vv_u32m2(a_u16, b_u16, 8);
+  vuint32m2_t zip_u32 = __riscv_vwmaccu_vx_u32m2(ab_waddu, UINT16_MAX, b_u16, 8);
+  vint16m2_t zip = __riscv_vreinterpret_v_i32m2_i16m2(__riscv_vreinterpret_v_u32m2_i32m2(zip_u32));
+  return __riscv_vget_v_i16m2_i16m1(zip, 0);
+}
 
 // FORCE_INLINE int32x2_t vzip1_s32(int32x2_t a, int32x2_t b);
 
-// FORCE_INLINE int32x4_t vzip1q_s32(int32x4_t a, int32x4_t b);
+FORCE_INLINE int32x4_t vzip1q_s32(int32x4_t a, int32x4_t b) {
+  vuint32m1_t a_u32 = __riscv_vreinterpret_v_i32m1_u32m1(a);
+  vuint32m1_t b_u32 = __riscv_vreinterpret_v_i32m1_u32m1(b);
+  vuint64m2_t ab_waddu = __riscv_vwaddu_vv_u64m2(a_u32, b_u32, 4);
+  vuint64m2_t zip_u64 = __riscv_vwmaccu_vx_u64m2(ab_waddu, UINT32_MAX, b_u32, 4);
+  vint32m2_t zip = __riscv_vreinterpret_v_i64m2_i32m2(__riscv_vreinterpret_v_u64m2_i64m2(zip_u64));
+  return __riscv_vget_v_i32m2_i32m1(zip, 0);
+}
 
-// FORCE_INLINE int64x2_t vzip1q_s64(int64x2_t a, int64x2_t b);
+FORCE_INLINE int64x2_t vzip1q_s64(int64x2_t a, int64x2_t b) {
+  return __riscv_vslideup_vx_i64m1(a, b, 1, 2);
+}
 
 // FORCE_INLINE uint8x8_t vzip1_u8(uint8x8_t a, uint8x8_t b);
 
@@ -10552,7 +10733,9 @@ FORCE_INLINE uint8x16_t vrev16q_u8(uint8x16_t a) {
 
 // FORCE_INLINE int32x4_t vzip2q_s32(int32x4_t a, int32x4_t b);
 
-// FORCE_INLINE int64x2_t vzip2q_s64(int64x2_t a, int64x2_t b);
+FORCE_INLINE int64x2_t vzip2q_s64(int64x2_t a, int64x2_t b) {
+  return __riscv_vslide1down_vx_i64m1(a, __riscv_vmv_x_s_i64m1_i64(__riscv_vslidedown_vx_i64m1(b, 1, 2)), 2);
+}
 
 // FORCE_INLINE uint8x8_t vzip2_u8(uint8x8_t a, uint8x8_t b);
 
@@ -10594,13 +10777,19 @@ FORCE_INLINE uint8x16_t vrev16q_u8(uint8x16_t a) {
 
 // FORCE_INLINE int32x2_t vuzp1_s32(int32x2_t a, int32x2_t b);
 
-// FORCE_INLINE int32x4_t vuzp1q_s32(int32x4_t a, int32x4_t b);
+FORCE_INLINE int32x4_t vuzp1q_s32(int32x4_t a, int32x4_t b) {
+  vint64m2_t ab = __riscv_vslideup_vx_i64m2(__riscv_vlmul_ext_v_i64m1_i64m2(__riscv_vreinterpret_v_i32m1_i64m1(a)), __riscv_vlmul_ext_v_i64m1_i64m2(__riscv_vreinterpret_v_i32m1_i64m1(b)), 2, 4);
+  return __riscv_vnsra_wx_i32m1(ab, 0, 4);
+}
 
 // FORCE_INLINE int64x2_t vuzp1q_s64(int64x2_t a, int64x2_t b);
 
 // FORCE_INLINE uint8x8_t vuzp1_u8(uint8x8_t a, uint8x8_t b);
 
-// FORCE_INLINE uint8x16_t vuzp1q_u8(uint8x16_t a, uint8x16_t b);
+FORCE_INLINE uint8x16_t vuzp1q_u8(uint8x16_t a, uint8x16_t b) {
+  vuint16m2_t ab = __riscv_vslideup_vx_u16m2(__riscv_vlmul_ext_v_u16m1_u16m2(__riscv_vreinterpret_v_u8m1_u16m1(a)), __riscv_vlmul_ext_v_u16m1_u16m2(__riscv_vreinterpret_v_u8m1_u16m1(b)), 8, 16);
+  return __riscv_vnsrl_wx_u8m1(ab, 0, 16);
+}
 
 // FORCE_INLINE uint16x4_t vuzp1_u16(uint16x4_t a, uint16x4_t b);
 
@@ -10684,11 +10873,20 @@ FORCE_INLINE uint8x16_t vrev16q_u8(uint8x16_t a) {
 
 // FORCE_INLINE int32x4_t vtrn1q_s32(int32x4_t a, int32x4_t b);
 
-// FORCE_INLINE int64x2_t vtrn1q_s64(int64x2_t a, int64x2_t b);
+FORCE_INLINE int64x2_t vtrn1q_s64(int64x2_t a, int64x2_t b) {
+  vbool64_t mask = __riscv_vmseq_vx_u64m1_b64(__riscv_vand_vx_u64m1(__riscv_vid_v_u64m1(2), 1, 2), 0, 2);
+  return __riscv_vmerge_vvm_i64m1(__riscv_vslide1up_vx_i64m1(b, 0, 2), a, mask, 2);
+}
 
-// FORCE_INLINE uint8x8_t vtrn1_u8(uint8x8_t a, uint8x8_t b);
+FORCE_INLINE uint8x8_t vtrn1_u8(uint8x8_t a, uint8x8_t b) {
+  vbool8_t mask = __riscv_vmseq_vx_u8m1_b8(__riscv_vand_vx_u8m1(__riscv_vid_v_u8m1(8), 1, 8), 0, 8);
+  return __riscv_vmerge_vvm_u8m1(__riscv_vslide1up_vx_u8m1(b, 0, 8), a, mask, 8);
+}
 
-// FORCE_INLINE uint8x16_t vtrn1q_u8(uint8x16_t a, uint8x16_t b);
+FORCE_INLINE uint8x16_t vtrn1q_u8(uint8x16_t a, uint8x16_t b) {
+  vbool8_t mask = __riscv_vmseq_vx_u8m1_b8(__riscv_vand_vx_u8m1(__riscv_vid_v_u8m1(16), 1, 16), 0, 16);
+  return __riscv_vmerge_vvm_u8m1(__riscv_vslide1up_vx_u8m1(b, 0, 16), a, mask, 16);
+}
 
 // FORCE_INLINE uint16x4_t vtrn1_u16(uint16x4_t a, uint16x4_t b);
 
@@ -10698,8 +10896,10 @@ FORCE_INLINE uint8x16_t vrev16q_u8(uint8x16_t a) {
 
 // FORCE_INLINE uint32x4_t vtrn1q_u32(uint32x4_t a, uint32x4_t b);
 
-// FORCE_INLINE uint64x2_t vtrn1q_u64(uint64x2_t a, uint64x2_t b);
-
+FORCE_INLINE uint64x2_t vtrn1q_u64(uint64x2_t a, uint64x2_t b) {
+  vbool64_t mask = __riscv_vmseq_vx_u64m1_b64(__riscv_vand_vx_u64m1(__riscv_vid_v_u64m1(2), 1, 2), 0, 2);
+  return __riscv_vmerge_vvm_u64m1(__riscv_vslide1up_vx_u64m1(b, 0, 2), a, mask, 2);
+}
 // FORCE_INLINE poly64x2_t vtrn1q_p64(poly64x2_t a, poly64x2_t b);
 
 // FORCE_INLINE float32x2_t vtrn1_f32(float32x2_t a, float32x2_t b);
@@ -10728,7 +10928,10 @@ FORCE_INLINE uint8x16_t vrev16q_u8(uint8x16_t a) {
 
 // FORCE_INLINE int32x4_t vtrn2q_s32(int32x4_t a, int32x4_t b);
 
-// FORCE_INLINE int64x2_t vtrn2q_s64(int64x2_t a, int64x2_t b);
+FORCE_INLINE int64x2_t vtrn2q_s64(int64x2_t a, int64x2_t b) {
+  vbool64_t mask = __riscv_vmseq_vx_u64m1_b64(__riscv_vand_vx_u64m1(__riscv_vid_v_u64m1(2), 1, 2), 0, 2);
+  return __riscv_vmerge_vvm_i64m1(b, __riscv_vslide1down_vx_i64m1(a, 0, 2), mask, 2);
+}
 
 // FORCE_INLINE uint8x8_t vtrn2_u8(uint8x8_t a, uint8x8_t b);
 
@@ -10742,7 +10945,10 @@ FORCE_INLINE uint8x16_t vrev16q_u8(uint8x16_t a) {
 
 // FORCE_INLINE uint32x4_t vtrn2q_u32(uint32x4_t a, uint32x4_t b);
 
-// FORCE_INLINE uint64x2_t vtrn2q_u64(uint64x2_t a, uint64x2_t b);
+FORCE_INLINE uint64x2_t vtrn2q_u64(uint64x2_t a, uint64x2_t b) {
+  vbool64_t mask = __riscv_vmseq_vx_u64m1_b64(__riscv_vand_vx_u64m1(__riscv_vid_v_u64m1(2), 1, 2), 0, 2);
+  return __riscv_vmerge_vvm_u64m1(b, __riscv_vslide1down_vx_u64m1(a, 0, 2), mask, 2);
+}
 
 // FORCE_INLINE poly64x2_t vtrn2q_p64(poly64x2_t a, poly64x2_t b);
 
@@ -11275,7 +11481,7 @@ FORCE_INLINE int8x16x2_t vzipq_s8(int8x16_t a, int8x16_t b) {
   vuint16m2_t ab_waddu = __riscv_vwaddu_vv_u16m2(a_u8, b_u8, 16);
   vuint16m2_t zip_u16 = __riscv_vwmaccu_vx_u16m2(ab_waddu, UINT8_MAX, b_u8, 16);
   vint8m2_t zip = __riscv_vreinterpret_v_i16m2_i8m2(__riscv_vreinterpret_v_u16m2_i16m2(zip_u16));
-  return __riscv_vcreate_v_i8m1x2(__riscv_vget_v_i8m2_i8m1(zip, 0), __riscv_vget_v_i8m2_i8m1(zip, 1));
+  return __riscv_vcreate_v_i8m1x2(__riscv_vget_v_i8m2_i8m1(zip, 0), __riscv_vget_v_i8m2_i8m1(__riscv_vslidedown_vx_i8m2(zip, 16, 32), 0));
 }
 
 FORCE_INLINE int16x8x2_t vzipq_s16(int16x8_t a, int16x8_t b) {
@@ -11284,7 +11490,7 @@ FORCE_INLINE int16x8x2_t vzipq_s16(int16x8_t a, int16x8_t b) {
   vuint32m2_t ab_waddu = __riscv_vwaddu_vv_u32m2(a_u16, b_u16, 8);
   vuint32m2_t zip_u32 = __riscv_vwmaccu_vx_u32m2(ab_waddu, UINT16_MAX, b_u16, 8);
   vint16m2_t zip = __riscv_vreinterpret_v_i32m2_i16m2(__riscv_vreinterpret_v_u32m2_i32m2(zip_u32));
-  return __riscv_vcreate_v_i16m1x2(__riscv_vget_v_i16m2_i16m1(zip, 0), __riscv_vget_v_i16m2_i16m1(zip, 1));
+  return __riscv_vcreate_v_i16m1x2(__riscv_vget_v_i16m2_i16m1(zip, 0), __riscv_vget_v_i16m2_i16m1(__riscv_vslidedown_vx_i16m2(zip, 8, 16), 0));
 }
 
 FORCE_INLINE int32x4x2_t vzipq_s32(int32x4_t a, int32x4_t b) {
@@ -11293,7 +11499,7 @@ FORCE_INLINE int32x4x2_t vzipq_s32(int32x4_t a, int32x4_t b) {
   vuint64m2_t ab_waddu = __riscv_vwaddu_vv_u64m2(a_u32, b_u32, 4);
   vuint64m2_t zip_u64 = __riscv_vwmaccu_vx_u64m2(ab_waddu, UINT32_MAX, b_u32, 4);
   vint32m2_t zip = __riscv_vreinterpret_v_i64m2_i32m2(__riscv_vreinterpret_v_u64m2_i64m2(zip_u64));
-  return __riscv_vcreate_v_i32m1x2(__riscv_vget_v_i32m2_i32m1(zip, 0), __riscv_vget_v_i32m2_i32m1(zip, 1));
+  return __riscv_vcreate_v_i32m1x2(__riscv_vget_v_i32m2_i32m1(zip, 0), __riscv_vget_v_i32m2_i32m1(__riscv_vslidedown_vx_i32m2(zip, 4, 8), 0));
 }
 
 FORCE_INLINE float32x4x2_t vzipq_f32(float32x4_t a, float32x4_t b) {
@@ -11303,28 +11509,28 @@ FORCE_INLINE float32x4x2_t vzipq_f32(float32x4_t a, float32x4_t b) {
   vuint64m2_t zip_u64 = __riscv_vwmaccu_vx_u64m2(ab_waddu, UINT32_MAX, b_u32, 4);
   vfloat32m2_t zip = __riscv_vreinterpret_v_i32m2_f32m2(
       __riscv_vreinterpret_v_i64m2_i32m2(__riscv_vreinterpret_v_u64m2_i64m2(zip_u64)));
-  return __riscv_vcreate_v_f32m1x2(__riscv_vget_v_f32m2_f32m1(zip, 0), __riscv_vget_v_f32m2_f32m1(zip, 1));
+  return __riscv_vcreate_v_f32m1x2(__riscv_vget_v_f32m2_f32m1(zip, 0), __riscv_vget_v_f32m2_f32m1(__riscv_vslidedown_vx_f32m2(zip, 4, 8), 0));
 }
 
 FORCE_INLINE uint8x16x2_t vzipq_u8(uint8x16_t a, uint8x16_t b) {
   vuint16m2_t ab_waddu = __riscv_vwaddu_vv_u16m2(a, b, 16);
   vuint16m2_t zip_u16 = __riscv_vwmaccu_vx_u16m2(ab_waddu, UINT8_MAX, b, 16);
   vuint8m2_t zip = __riscv_vreinterpret_v_u16m2_u8m2(zip_u16);
-  return __riscv_vcreate_v_u8m1x2(__riscv_vget_v_u8m2_u8m1(zip, 0), __riscv_vget_v_u8m2_u8m1(zip, 1));
+  return __riscv_vcreate_v_u8m1x2(__riscv_vget_v_u8m2_u8m1(zip, 0), __riscv_vget_v_u8m2_u8m1(__riscv_vslidedown_vx_u8m2(zip, 16, 32), 0));
 }
 
 FORCE_INLINE uint16x8x2_t vzipq_u16(uint16x8_t a, uint16x8_t b) {
   vuint32m2_t ab_waddu = __riscv_vwaddu_vv_u32m2(a, b, 8);
   vuint32m2_t zip_u32 = __riscv_vwmaccu_vx_u32m2(ab_waddu, UINT16_MAX, b, 8);
   vuint16m2_t zip = __riscv_vreinterpret_v_u32m2_u16m2(zip_u32);
-  return __riscv_vcreate_v_u16m1x2(__riscv_vget_v_u16m2_u16m1(zip, 0), __riscv_vget_v_u16m2_u16m1(zip, 1));
+  return __riscv_vcreate_v_u16m1x2(__riscv_vget_v_u16m2_u16m1(zip, 0), __riscv_vget_v_u16m2_u16m1(__riscv_vslidedown_vx_u16m2(zip, 8, 16), 0));
 }
 
 FORCE_INLINE uint32x4x2_t vzipq_u32(uint32x4_t a, uint32x4_t b) {
   vuint64m2_t ab_waddu = __riscv_vwaddu_vv_u64m2(a, b, 4);
   vuint64m2_t zip_u64 = __riscv_vwmaccu_vx_u64m2(ab_waddu, UINT32_MAX, b, 4);
   vuint32m2_t zip = __riscv_vreinterpret_v_u64m2_u32m2(zip_u64);
-  return __riscv_vcreate_v_u32m1x2(__riscv_vget_v_u32m2_u32m1(zip, 0), __riscv_vget_v_u32m2_u32m1(zip, 1));
+  return __riscv_vcreate_v_u32m1x2(__riscv_vget_v_u32m2_u32m1(zip, 0), __riscv_vget_v_u32m2_u32m1(__riscv_vslidedown_vx_u32m2(zip, 4, 8), 0));
 }
 
 // FORCE_INLINE poly8x16x2_t vzipq_p8(poly8x16_t a, poly8x16_t b);
@@ -11393,57 +11599,56 @@ FORCE_INLINE uint32x2x2_t vuzp_u32(uint32x2_t a, uint32x2_t b) {
 // FORCE_INLINE poly16x4x2_t vuzp_p16(poly16x4_t a, poly16x4_t b);
 
 FORCE_INLINE int8x16x2_t vuzpq_s8(int8x16_t a, int8x16_t b) {
-  vint16m2_t ab = __riscv_vset_v_i16m1_i16m2(__riscv_vmv_s_x_i16m2(0, 16), 0, __riscv_vreinterpret_v_i8m1_i16m1(a));
-  ab = __riscv_vset_v_i16m1_i16m2(ab, 1, __riscv_vreinterpret_v_i8m1_i16m1(b));
+  vint16m2_t ab = __riscv_vslideup_vx_i16m2(__riscv_vlmul_ext_v_i16m1_i16m2(__riscv_vreinterpret_v_i8m1_i16m1(a)),
+                    __riscv_vlmul_ext_v_i16m1_i16m2(__riscv_vreinterpret_v_i8m1_i16m1(b)), 8, 16);
   vint8m1_t uzp1 = __riscv_vnsra_wx_i8m1(ab, 0, 16);
   vint8m1_t uzp2 = __riscv_vnsra_wx_i8m1(ab, 8, 16);
   return __riscv_vcreate_v_i8m1x2(uzp1, uzp2);
 }
 
 FORCE_INLINE int16x8x2_t vuzpq_s16(int16x8_t a, int16x8_t b) {
-  vint32m2_t ab = __riscv_vset_v_i32m1_i32m2(__riscv_vmv_s_x_i32m2(0, 8), 0, __riscv_vreinterpret_v_i16m1_i32m1(a));
-  ab = __riscv_vset_v_i32m1_i32m2(ab, 1, __riscv_vreinterpret_v_i16m1_i32m1(b));
+  vint32m2_t ab = __riscv_vslideup_vx_i32m2(__riscv_vlmul_ext_v_i32m1_i32m2(__riscv_vreinterpret_v_i16m1_i32m1(a)),
+                    __riscv_vlmul_ext_v_i32m1_i32m2(__riscv_vreinterpret_v_i16m1_i32m1(b)), 4, 8);
   vint16m1_t uzp1 = __riscv_vnsra_wx_i16m1(ab, 0, 8);
   vint16m1_t uzp2 = __riscv_vnsra_wx_i16m1(ab, 16, 8);
   return __riscv_vcreate_v_i16m1x2(uzp1, uzp2);
 }
 
 FORCE_INLINE int32x4x2_t vuzpq_s32(int32x4_t a, int32x4_t b) {
-  vint64m2_t ab = __riscv_vset_v_i64m1_i64m2(__riscv_vmv_s_x_i64m2(0, 4), 0, __riscv_vreinterpret_v_i32m1_i64m1(a));
-  ab = __riscv_vset_v_i64m1_i64m2(ab, 1, __riscv_vreinterpret_v_i32m1_i64m1(b));
+  vint64m2_t ab = __riscv_vslideup_vx_i64m2(__riscv_vlmul_ext_v_i64m1_i64m2(__riscv_vreinterpret_v_i32m1_i64m1(a)),
+                    __riscv_vlmul_ext_v_i64m1_i64m2(__riscv_vreinterpret_v_i32m1_i64m1(b)), 2, 4);
   vint32m1_t uzp1 = __riscv_vnsra_wx_i32m1(ab, 0, 4);
   vint32m1_t uzp2 = __riscv_vnsra_wx_i32m1(ab, 32, 4);
   return __riscv_vcreate_v_i32m1x2(uzp1, uzp2);
 }
 
 FORCE_INLINE float32x4x2_t vuzpq_f32(float32x4_t a, float32x4_t b) {
-  vint64m2_t ab = __riscv_vset_v_i64m1_i64m2(__riscv_vmv_s_x_i64m2(0, 4), 0,
-                                             __riscv_vreinterpret_v_i32m1_i64m1(__riscv_vreinterpret_v_f32m1_i32m1(a)));
-  ab = __riscv_vset_v_i64m1_i64m2(ab, 1, __riscv_vreinterpret_v_i32m1_i64m1(__riscv_vreinterpret_v_f32m1_i32m1(b)));
+  vint64m2_t  ab = __riscv_vslideup_vx_i64m2(__riscv_vlmul_ext_v_i64m1_i64m2(__riscv_vreinterpret_v_i32m1_i64m1(__riscv_vreinterpret_v_f32m1_i32m1(a))),
+                    __riscv_vlmul_ext_v_i64m1_i64m2(__riscv_vreinterpret_v_i32m1_i64m1(__riscv_vreinterpret_v_f32m1_i32m1(b))), 2, 4);
   vfloat32m1_t uzp1 = __riscv_vreinterpret_v_i32m1_f32m1(__riscv_vnsra_wx_i32m1(ab, 0, 4));
   vfloat32m1_t uzp2 = __riscv_vreinterpret_v_i32m1_f32m1(__riscv_vnsra_wx_i32m1(ab, 32, 4));
   return __riscv_vcreate_v_f32m1x2(uzp1, uzp2);
 }
 
 FORCE_INLINE uint8x16x2_t vuzpq_u8(uint8x16_t a, uint8x16_t b) {
-  vuint16m2_t ab = __riscv_vset_v_u16m1_u16m2(__riscv_vmv_s_x_u16m2(0, 16), 0, __riscv_vreinterpret_v_u8m1_u16m1(a));
-  ab = __riscv_vset_v_u16m1_u16m2(ab, 1, __riscv_vreinterpret_v_u8m1_u16m1(b));
+  vuint16m2_t ab = __riscv_vslideup_vx_u16m2(__riscv_vlmul_ext_v_u16m1_u16m2(__riscv_vreinterpret_v_u8m1_u16m1(a)),
+                    __riscv_vlmul_ext_v_u16m1_u16m2(__riscv_vreinterpret_v_u8m1_u16m1(b)), 8, 16);
   vuint8m1_t uzp1 = __riscv_vnsrl_wx_u8m1(ab, 0, 16);
   vuint8m1_t uzp2 = __riscv_vnsrl_wx_u8m1(ab, 8, 16);
   return __riscv_vcreate_v_u8m1x2(uzp1, uzp2);
 }
 
 FORCE_INLINE uint16x8x2_t vuzpq_u16(uint16x8_t a, uint16x8_t b) {
-  vuint32m2_t ab = __riscv_vset_v_u32m1_u32m2(__riscv_vmv_s_x_u32m2(0, 8), 0, __riscv_vreinterpret_v_u16m1_u32m1(a));
-  ab = __riscv_vset_v_u32m1_u32m2(ab, 1, __riscv_vreinterpret_v_u16m1_u32m1(b));
+  vuint32m2_t ab = __riscv_vslideup_vx_u32m2(__riscv_vlmul_ext_v_u32m1_u32m2(__riscv_vreinterpret_v_u16m1_u32m1(a)),
+                    __riscv_vlmul_ext_v_u32m1_u32m2(__riscv_vreinterpret_v_u16m1_u32m1(b)), 4, 8);
   vuint16m1_t uzp1 = __riscv_vnsrl_wx_u16m1(ab, 0, 8);
   vuint16m1_t uzp2 = __riscv_vnsrl_wx_u16m1(ab, 16, 8);
   return __riscv_vcreate_v_u16m1x2(uzp1, uzp2);
 }
 
 FORCE_INLINE uint32x4x2_t vuzpq_u32(uint32x4_t a, uint32x4_t b) {
-  vuint64m2_t ab = __riscv_vset_v_u64m1_u64m2(__riscv_vmv_s_x_u64m2(0, 4), 0, __riscv_vreinterpret_v_u32m1_u64m1(a));
-  ab = __riscv_vset_v_u64m1_u64m2(ab, 1, __riscv_vreinterpret_v_u32m1_u64m1(b));
+  vuint64m2_t ab = __riscv_vslideup_vx_u64m2(__riscv_vlmul_ext_v_u64m1_u64m2(__riscv_vreinterpret_v_u32m1_u64m1(a)),
+                    __riscv_vlmul_ext_v_u64m1_u64m2(__riscv_vreinterpret_v_u32m1_u64m1(b)), 2, 4);
   vuint32m1_t uzp1 = __riscv_vnsrl_wx_u32m1(ab, 0, 4);
   vuint32m1_t uzp2 = __riscv_vnsrl_wx_u32m1(ab, 32, 4);
   return __riscv_vcreate_v_u32m1x2(uzp1, uzp2);
@@ -13565,7 +13770,9 @@ FORCE_INLINE void vst1q_f64_x2(float64_t *ptr, float64x2x2_t val) {
 
 // FORCE_INLINE int8x8x2_t vld1_s8_x2(int8_t const * ptr);
 
-// FORCE_INLINE int8x16x2_t vld1q_s8_x2(int8_t const * ptr);
+FORCE_INLINE int8x16x2_t vld1q_s8_x2(int8_t const * ptr) {
+  return __riscv_vcreate_v_i8m1x2( __riscv_vle8_v_i8m1(ptr , 16), __riscv_vle8_v_i8m1(ptr + 16 , 16));
+}
 
 // FORCE_INLINE int16x4x2_t vld1_s16_x2(int16_t const * ptr);
 
@@ -13577,11 +13784,15 @@ FORCE_INLINE void vst1q_f64_x2(float64_t *ptr, float64x2x2_t val) {
 
 // FORCE_INLINE uint8x8x2_t vld1_u8_x2(uint8_t const * ptr);
 
-// FORCE_INLINE uint8x16x2_t vld1q_u8_x2(uint8_t const * ptr);
+FORCE_INLINE uint8x16x2_t vld1q_u8_x2(uint8_t const * ptr) {
+  return __riscv_vcreate_v_u8m1x2( __riscv_vle8_v_u8m1(ptr , 16), __riscv_vle8_v_u8m1(ptr + 16 , 16));
+}
 
 // FORCE_INLINE uint16x4x2_t vld1_u16_x2(uint16_t const * ptr);
 
-// FORCE_INLINE uint16x8x2_t vld1q_u16_x2(uint16_t const * ptr);
+FORCE_INLINE uint16x8x2_t vld1q_u16_x2(uint16_t const * ptr) {
+  return __riscv_vcreate_v_u16m1x2( __riscv_vle16_v_u16m1(ptr , 8), __riscv_vle16_v_u16m1(ptr + 8 , 8));
+}
 
 // FORCE_INLINE uint32x2x2_t vld1_u32_x2(uint32_t const * ptr);
 
@@ -13633,11 +13844,15 @@ FORCE_INLINE void vst1q_f64_x2(float64_t *ptr, float64x2x2_t val) {
 
 // FORCE_INLINE uint8x8x3_t vld1_u8_x3(uint8_t const * ptr);
 
-// FORCE_INLINE uint8x16x3_t vld1q_u8_x3(uint8_t const * ptr);
+FORCE_INLINE uint8x16x3_t vld1q_u8_x3(uint8_t const * ptr) {
+  return __riscv_vcreate_v_u8m1x3( __riscv_vle8_v_u8m1(ptr , 16), __riscv_vle8_v_u8m1(ptr + 16 , 16), __riscv_vle8_v_u8m1(ptr + 32 , 16));
+}
 
 // FORCE_INLINE uint16x4x3_t vld1_u16_x3(uint16_t const * ptr);
 
-// FORCE_INLINE uint16x8x3_t vld1q_u16_x3(uint16_t const * ptr);
+FORCE_INLINE uint16x8x3_t vld1q_u16_x3(uint16_t const * ptr) {
+  return __riscv_vcreate_v_u16m1x3( __riscv_vle16_v_u16m1(ptr , 8), __riscv_vle16_v_u16m1(ptr + 8 , 8), __riscv_vle16_v_u16m1(ptr + 16 , 8));
+}
 
 // FORCE_INLINE uint32x2x3_t vld1_u32_x3(uint32_t const * ptr);
 
@@ -13689,11 +13904,15 @@ FORCE_INLINE void vst1q_f64_x2(float64_t *ptr, float64x2x2_t val) {
 
 // FORCE_INLINE uint8x8x4_t vld1_u8_x4(uint8_t const * ptr);
 
-// FORCE_INLINE uint8x16x4_t vld1q_u8_x4(uint8_t const * ptr);
+FORCE_INLINE uint8x16x4_t vld1q_u8_x4(uint8_t const * ptr) {
+  return __riscv_vcreate_v_u8m1x4( __riscv_vle8_v_u8m1(ptr , 16), __riscv_vle8_v_u8m1(ptr + 16 , 16), __riscv_vle8_v_u8m1(ptr + 32 , 16), __riscv_vle8_v_u8m1(ptr + 48 , 16));
+}
 
 // FORCE_INLINE uint16x4x4_t vld1_u16_x4(uint16_t const * ptr);
 
-// FORCE_INLINE uint16x8x4_t vld1q_u16_x4(uint16_t const * ptr);
+FORCE_INLINE uint16x8x4_t vld1q_u16_x4(uint16_t const * ptr) {
+  return __riscv_vcreate_v_u16m1x4( __riscv_vle16_v_u16m1(ptr , 8), __riscv_vle16_v_u16m1(ptr + 8 , 8), __riscv_vle16_v_u16m1(ptr + 16 , 8), __riscv_vle16_v_u16m1(ptr + 24 , 8));
+}
 
 // FORCE_INLINE uint32x2x4_t vld1_u32_x4(uint32_t const * ptr);
 

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -15517,29 +15517,197 @@ result_t test_vaddvq_f64(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
 #endif  // ENABLE_TEST_ALL
 }
 
-result_t test_vaddlv_s8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+result_t test_vaddlv_s8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const int8_t *_a = (int8_t *)impl.test_cases_int_pointer1;
+  int16_t _c = 0;
+  for (int i = 0; i < 8; i++) {
+    _c += _a[i];
+  }
 
-result_t test_vaddlvq_s8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+  int8x8_t a = vld1_s8(_a);
+  int16_t c = vaddlv_s8(a);
+  return c == _c ? TEST_SUCCESS : TEST_FAIL;
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
 
-result_t test_vaddlv_s16(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+result_t test_vaddlvq_s8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const int8_t *_a = (int8_t *)impl.test_cases_int_pointer1;
+  int16_t _c = 0;
+  for (int i = 0; i < 16; i++) {
+    _c += _a[i];
+  }
 
-result_t test_vaddlvq_s16(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+  int8x16_t a = vld1q_s8(_a);
+  int16_t c = vaddlvq_s8(a);
+  return c == _c ? TEST_SUCCESS : TEST_FAIL;
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
 
-result_t test_vaddlv_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+result_t test_vaddlv_s16(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const int16_t *_a = (int16_t *)impl.test_cases_int_pointer1;
+  int32_t _c = 0;
+  for (int i = 0; i < 4; i++) {
+    _c += _a[i];
+  }
 
-result_t test_vaddlvq_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+  int16x4_t a = vld1_s16(_a);
+  int32_t c = vaddlv_s16(a);
+  return c == _c ? TEST_SUCCESS : TEST_FAIL;
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
 
-result_t test_vaddlv_u8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+result_t test_vaddlvq_s16(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const int16_t *_a = (int16_t *)impl.test_cases_int_pointer1;
+  int32_t _c = 0;
+  for (int i = 0; i < 8; i++) {
+    _c += _a[i];
+  }
 
-result_t test_vaddlvq_u8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+  int16x8_t a = vld1q_s16(_a);
+  int32_t c = vaddlvq_s16(a);
+  return c == _c ? TEST_SUCCESS : TEST_FAIL;
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
 
-result_t test_vaddlv_u16(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+result_t test_vaddlv_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const int32_t *_a = (int32_t *)impl.test_cases_int_pointer1;
+  int64_t _c = 0;
+  for (int i = 0; i < 2; i++) {
+    _c += _a[i];
+  }
 
-result_t test_vaddlvq_u16(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+  int32x2_t a = vld1_s32(_a);
+  int64_t c = vaddlv_s32(a);
+  return c == _c ? TEST_SUCCESS : TEST_FAIL;
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
 
-result_t test_vaddlv_u32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+result_t test_vaddlvq_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const int32_t *_a = (int32_t *)impl.test_cases_int_pointer1;
+  int64_t _c = 0;
+  for (int i = 0; i < 4; i++) {
+    _c += _a[i];
+  }
 
-result_t test_vaddlvq_u32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+  int32x4_t a = vld1q_s32(_a);
+  int64_t c = vaddlvq_s32(a);
+  return c == _c ? TEST_SUCCESS : TEST_FAIL;
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
+
+result_t test_vaddlv_u8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { 
+  #ifdef ENABLE_TEST_ALL
+  const uint8_t *_a = (uint8_t *)impl.test_cases_int_pointer1;
+  uint16_t _c = 0;
+  for (int i = 0; i < 8; i++) {
+    _c += _a[i];
+  }
+
+  uint8x8_t a = vld1_u8(_a);
+  uint16_t c = vaddlv_u8(a);
+  return c == _c ? TEST_SUCCESS : TEST_FAIL;
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
+
+result_t test_vaddlvq_u8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { 
+  #ifdef ENABLE_TEST_ALL
+  const uint8_t *_a = (uint8_t *)impl.test_cases_int_pointer1;
+  uint16_t _c = 0;
+  for (int i = 0; i < 16; i++) {
+    _c += _a[i];
+  }
+
+  uint8x16_t a = vld1q_u8(_a);
+  uint16_t c = vaddlvq_u8(a);
+  return c == _c ? TEST_SUCCESS : TEST_FAIL;
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
+
+result_t test_vaddlv_u16(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const uint16_t *_a = (uint16_t *)impl.test_cases_int_pointer1;
+  uint32_t _c = 0;
+  for (int i = 0; i < 4; i++) {
+    _c += _a[i];
+  }
+
+  uint16x4_t a = vld1_u16(_a);
+  uint32_t c = vaddlv_u16(a);
+  return c == _c ? TEST_SUCCESS : TEST_FAIL;
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
+
+result_t test_vaddlvq_u16(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const uint16_t *_a = (uint16_t *)impl.test_cases_int_pointer1;
+  uint32_t _c = 0;
+  for (int i = 0; i < 8; i++) {
+    _c += _a[i];
+  }
+
+  uint16x8_t a = vld1q_u16(_a);
+  uint32_t c = vaddlvq_u16(a);
+  return c == _c ? TEST_SUCCESS : TEST_FAIL;
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
+
+result_t test_vaddlv_u32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const uint32_t *_a = (uint32_t *)impl.test_cases_int_pointer1;
+  uint64_t _c = 0;
+  for (int i = 0; i < 2; i++) {
+    _c += _a[i];
+  }
+
+  uint32x2_t a = vld1_u32(_a);
+  uint64_t c = vaddlv_u32(a);
+  return c == _c ? TEST_SUCCESS : TEST_FAIL;
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
+
+result_t test_vaddlvq_u32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const uint32_t *_a = (uint32_t *)impl.test_cases_int_pointer1;
+  uint64_t _c = 0;
+  for (int i = 0; i < 4; i++) {
+    _c += _a[i];
+  }
+
+  uint32x4_t a = vld1q_u32(_a);
+  uint64_t c = vaddlvq_u32(a);
+  return c == _c ? TEST_SUCCESS : TEST_FAIL;
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
 
 result_t test_vmaxv_s8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
 #ifdef ENABLE_TEST_ALL
@@ -27798,11 +27966,61 @@ result_t test_vtbx4_p8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return T
 
 result_t test_vqtbl1_s8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
 
-result_t test_vqtbl1q_s8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+result_t test_vqtbl1q_s8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const int8_t *_a = (int8_t *)impl.test_cases_int_pointer1;
+  const uint8_t *_b = (uint8_t *)impl.test_cases_int_pointer2;
+  int8_t _c[16];
+  for (int i = 0; i < 16; i++) {
+    _c[i] = (_b[i] < 16) ? _a[_b[i]] : 0;
+  }
 
-result_t test_vqtbl1_u8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+  int8x16_t a = vld1q_s8(_a);
+  uint8x16_t b = vld1q_u8(_b);
+  int8x16_t c = vqtbl1q_s8(a, b);
+  return validate_int8(c, _c[0], _c[1], _c[2], _c[3], _c[4], _c[5], _c[6], _c[7], _c[8], _c[9], _c[10], _c[11], _c[12],
+                        _c[13], _c[14], _c[15]);
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
 
-result_t test_vqtbl1q_u8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+result_t test_vqtbl1_u8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const uint8_t *_a = (uint8_t *)impl.test_cases_int_pointer1;
+  const uint8_t *_b = (uint8_t *)impl.test_cases_int_pointer2;
+  uint8_t _c[8];
+  for (int i = 0; i < 8; i++) {
+    _c[i] = (_b[i] < 16) ? _a[_b[i]] : 0;
+  }
+
+  uint8x16_t a = vld1q_u8(_a);
+  uint8x8_t b = vld1_u8(_b);
+  uint8x8_t c = vqtbl1_u8(a, b);
+  return validate_uint8(c, _c[0], _c[1], _c[2], _c[3], _c[4], _c[5], _c[6], _c[7]);
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
+
+result_t test_vqtbl1q_u8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const uint8_t *_a = (uint8_t *)impl.test_cases_int_pointer1;
+  const uint8_t *_b = (uint8_t *)impl.test_cases_int_pointer2;
+  uint8_t _c[16];
+  for (int i = 0; i < 16; i++) {
+    _c[i] = (_b[i] < 16) ? _a[_b[i]] : 0;
+  }
+
+  uint8x16_t a = vld1q_u8(_a);
+  uint8x16_t b = vld1q_u8(_b);
+  uint8x16_t c = vqtbl1q_u8(a, b);
+  return validate_uint8(c, _c[0], _c[1], _c[2], _c[3], _c[4], _c[5], _c[6], _c[7], _c[8], _c[9], _c[10], _c[11], _c[12],
+                        _c[13], _c[14], _c[15]);
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
 
 result_t test_vqtbl1_p8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
 
@@ -27822,11 +28040,61 @@ result_t test_vqtbx1q_p8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return
 
 result_t test_vqtbl2_s8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
 
-result_t test_vqtbl2q_s8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+result_t test_vqtbl2q_s8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const int8_t *_a = (int8_t *)impl.test_cases_int_pointer1;
+  const uint8_t *_b = (uint8_t *)impl.test_cases_int_pointer2;
+  int8_t _c[16];
+  for (int i = 0; i < 16; i++) {
+    _c[i] = (_b[i] < 32) ? _a[_b[i]] : 0;
+  }
 
-result_t test_vqtbl2_u8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+  int8x16x2_t a = vld1q_s8_x2(_a);
+  uint8x16_t b = vld1q_u8(_b);
+  int8x16_t c = vqtbl2q_s8(a, b);
+  return validate_int8(c, _c[0], _c[1], _c[2], _c[3], _c[4], _c[5], _c[6], _c[7], _c[8], _c[9], _c[10], _c[11], _c[12],
+                        _c[13], _c[14], _c[15]);
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
 
-result_t test_vqtbl2q_u8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+result_t test_vqtbl2_u8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const uint8_t *_a = (uint8_t *)impl.test_cases_int_pointer1;
+  const uint8_t *_b = (uint8_t *)impl.test_cases_int_pointer2;
+  uint8_t _c[8];
+  for (int i = 0; i < 8; i++) {
+    _c[i] = (_b[i] < 32) ? _a[_b[i]] : 0;
+  }
+
+  uint8x16x2_t a = vld1q_u8_x2(_a);
+  uint8x8_t b = vld1_u8(_b);
+  uint8x8_t c = vqtbl2_u8(a, b);
+  return validate_uint8(c, _c[0], _c[1], _c[2], _c[3], _c[4], _c[5], _c[6], _c[7]);
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
+
+result_t test_vqtbl2q_u8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const uint8_t *_a = (uint8_t *)impl.test_cases_int_pointer1;
+  const uint8_t *_b = (uint8_t *)impl.test_cases_int_pointer2;
+  uint8_t _c[16];
+  for (int i = 0; i < 16; i++) {
+    _c[i] = (_b[i] < 32) ? _a[_b[i]] : 0;
+  }
+
+  uint8x16x2_t a = vld1q_u8_x2(_a);
+  uint8x16_t b = vld1q_u8(_b);
+  uint8x16_t c = vqtbl2q_u8(a, b);
+  return validate_uint8(c, _c[0], _c[1], _c[2], _c[3], _c[4], _c[5], _c[6], _c[7], _c[8], _c[9], _c[10], _c[11], _c[12],
+                        _c[13], _c[14], _c[15]);
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
 
 result_t test_vqtbl2_p8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
 
@@ -27838,7 +28106,24 @@ result_t test_vqtbl3q_s8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return
 
 result_t test_vqtbl3_u8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
 
-result_t test_vqtbl3q_u8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+result_t test_vqtbl3q_u8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const uint8_t *_a = (uint8_t *)impl.test_cases_int_pointer1;
+  const uint8_t *_b = (uint8_t *)impl.test_cases_int_pointer2;
+  uint8_t _c[16];
+  for (int i = 0; i < 16; i++) {
+    _c[i] = (_b[i] < 48) ? _a[_b[i]] : 0;
+  }
+
+  uint8x16x3_t a = vld1q_u8_x3(_a);
+  uint8x16_t b = vld1q_u8(_b);
+  uint8x16_t c = vqtbl3q_u8(a, b);
+  return validate_uint8(c, _c[0], _c[1], _c[2], _c[3], _c[4], _c[5], _c[6], _c[7], _c[8], _c[9], _c[10], _c[11], _c[12],
+                        _c[13], _c[14], _c[15]);
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
 
 result_t test_vqtbl3_p8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
 
@@ -27850,7 +28135,24 @@ result_t test_vqtbl4q_s8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return
 
 result_t test_vqtbl4_u8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
 
-result_t test_vqtbl4q_u8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+result_t test_vqtbl4q_u8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const uint8_t *_a = (uint8_t *)impl.test_cases_int_pointer1;
+  const uint8_t *_b = (uint8_t *)impl.test_cases_int_pointer2;
+  uint8_t _c[16];
+  for (int i = 0; i < 16; i++) {
+    _c[i] = (_b[i] < 64) ? _a[_b[i]] : 0;
+  }
+
+  uint8x16x4_t a = vld1q_u8_x4(_a);
+  uint8x16_t b = vld1q_u8(_b);
+  uint8x16_t c = vqtbl4q_u8(a, b);
+  return validate_uint8(c, _c[0], _c[1], _c[2], _c[3], _c[4], _c[5], _c[6], _c[7], _c[8], _c[9], _c[10], _c[11], _c[12],
+                        _c[13], _c[14], _c[15]);
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
 
 result_t test_vqtbl4_p8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
 
@@ -30305,11 +30607,56 @@ result_t test_vduph_lane_f16(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { re
 
 result_t test_vduph_laneq_f16(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
 
-result_t test_vdot_u32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+result_t test_vdot_u32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const uint8_t *_a = (uint8_t *)impl.test_cases_int_pointer1;
+  const uint8_t *_b = (uint8_t *)impl.test_cases_int_pointer2;
+  const uint32_t *_r = (uint32_t *)impl.test_cases_int_pointer3;
+  const int lane_num = 2;
+  uint32_t _c[lane_num];
+  for (int i = 0; i < lane_num; i++) {
+    _c[i]=_r[i];
+    for (int j = 0; j < 4; j++) {
+      _c[i] += (uint32_t)_a[(i<<2)+j]*_b[(i<<2)+j];
+    }
+  }
+
+  uint8x8_t a = vld1_u8(_a);
+  uint8x8_t b = vld1_u8(_b);
+  uint32x2_t r = vld1_u32(_r);
+  uint32x2_t c = vdot_u32(r, a, b);
+  return validate_uint32(c, _c[0], _c[1]);
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
 
 result_t test_vdot_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
 
-result_t test_vdotq_u32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+result_t test_vdotq_u32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const uint8_t *_a = (uint8_t *)impl.test_cases_int_pointer1;
+  const uint8_t *_b = (uint8_t *)impl.test_cases_int_pointer2;
+  const uint32_t *_r = (uint32_t *)impl.test_cases_int_pointer3;
+  const int lane_num = 4;
+  uint32_t _c[lane_num];
+  for (int i = 0; i < lane_num; i++) {
+    _c[i]=_r[i];
+    for (int j = 0; j < 4; j++) {
+      _c[i] += (uint32_t)_a[(i<<2)+j]*_b[(i<<2)+j];
+    }
+  }
+
+  uint8x16_t a = vld1q_u8(_a);
+  uint8x16_t b = vld1q_u8(_b);
+  uint32x4_t r = vld1q_u32(_r);
+  uint32x4_t c = vdotq_u32(r, a, b);
+  return validate_uint32(c, _c[0], _c[1], _c[2], _c[3]);
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
+
 
 result_t test_vdotq_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
 
@@ -30319,7 +30666,37 @@ result_t test_vdot_lane_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { ret
 
 result_t test_vdotq_laneq_u32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
 
-result_t test_vdotq_laneq_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+result_t test_vdotq_laneq_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const int8_t *_a = (int8_t *)impl.test_cases_int_pointer1;
+  const int8_t *_b = (int8_t *)impl.test_cases_int_pointer2;
+  const int32_t *_r = (int32_t *)impl.test_cases_int_pointer3;
+  const int lane_num = 4;
+  int32_t _c[lane_num];
+  int8x16_t a, b;
+  int32x4_t r, c;
+
+#define TEST_IMPL(IDX)                         \
+  for (int i = 0; i < lane_num; i++) {         \
+    _c[i]=_r[i];                               \
+    for (int j = 0; j < 4; j++) {              \
+      _c[i] += (int32_t)_a[(i<<2)+j]*_b[(IDX<<2)+j]; \
+    }                                          \
+  }                                            \
+  a = vld1q_s8(_a);                            \
+  b = vld1q_s8(_b);                            \
+  r = vld1q_s32(_r);                           \
+  c = vdotq_laneq_s32(r, a, b, IDX);           \
+  CHECK_RESULT(validate_int32(c, _c[0], _c[1], _c[2], _c[3]))
+
+  IMM_4_ITER
+#undef TEST_IMPL
+
+  return TEST_SUCCESS;
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
 
 result_t test_vdot_laneq_u32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
 
@@ -30327,7 +30704,38 @@ result_t test_vdot_laneq_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { re
 
 result_t test_vdotq_lane_u32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
 
-result_t test_vdotq_lane_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+result_t test_vdotq_lane_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const int8_t *_a = (int8_t *)impl.test_cases_int_pointer1;
+  const int8_t *_b = (int8_t *)impl.test_cases_int_pointer2;
+  const int32_t *_r = (int32_t *)impl.test_cases_int_pointer3;
+  const int lane_num = 4;
+  int32_t _c[lane_num];
+  int8x16_t a;
+  int8x8_t b;
+  int32x4_t r, c;
+
+#define TEST_IMPL(IDX)                         \
+  for (int i = 0; i < lane_num; i++) {         \
+    _c[i]=_r[i];                               \
+    for (int j = 0; j < 4; j++) {              \
+      _c[i] += (int32_t)_a[(i<<2)+j]*_b[(IDX<<2)+j]; \
+    }                                          \
+  }                                            \
+  a = vld1q_s8(_a);                            \
+  b = vld1_s8(_b);                             \
+  r = vld1q_s32(_r);                           \
+  c = vdotq_lane_s32(r, a, b, IDX);            \
+  CHECK_RESULT(validate_int32(c, _c[0], _c[1], _c[2], _c[3]))
+
+  IMM_2_ITER
+#undef TEST_IMPL
+
+  return TEST_SUCCESS;
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
 
 result_t test_vsha512hq_u64(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
 
@@ -30611,13 +31019,97 @@ result_t test_vusdot_laneq_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { 
 
 result_t test_vsudot_laneq_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
 
-result_t test_vusdotq_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+result_t test_vusdotq_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const uint8_t *_a = (uint8_t *)impl.test_cases_int_pointer1;
+  const int8_t *_b = (int8_t *)impl.test_cases_int_pointer2;
+  const int32_t *_r = (int32_t *)impl.test_cases_int_pointer3;
+  const int lane_num = 4;
+  int32_t _c[lane_num];
+  for (int i = 0; i < lane_num; i++) {
+    _c[i]=_r[i];
+    for (int j = 0; j < 4; j++) {
+      _c[i] += (int32_t)_a[(i<<2)+j]*_b[(i<<2)+j];
+    }
+  }
 
-result_t test_vusdotq_lane_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+  uint8x16_t a = vld1q_u8(_a);
+  int8x16_t b = vld1q_s8(_b);
+  int32x4_t r = vld1q_s32(_r);
+  int32x4_t c = vusdotq_s32(r, a, b);
+  return validate_int32(c, _c[0], _c[1], _c[2], _c[3]);
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
+
+result_t test_vusdotq_lane_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const uint8_t *_a = (uint8_t *)impl.test_cases_int_pointer1;
+  const int8_t *_b = (int8_t *)impl.test_cases_int_pointer2;
+  const int32_t *_r = (int32_t *)impl.test_cases_int_pointer3;
+  const int lane_num = 4;
+  int32_t _c[lane_num];
+  uint8x16_t a;
+  int8x8_t b;
+  int32x4_t r, c;
+
+#define TEST_IMPL(IDX)                         \
+  for (int i = 0; i < lane_num; i++) {         \
+    _c[i]=_r[i];                               \
+    for (int j = 0; j < 4; j++) {              \
+      _c[i] += (int32_t)_a[(i<<2)+j]*_b[(IDX<<2)+j]; \
+    }                                          \
+  }                                            \
+  a = vld1q_u8(_a);                            \
+  b = vld1_s8(_b);                             \
+  r = vld1q_s32(_r);                           \
+  c = vusdotq_lane_s32(r, a, b, IDX);          \
+  CHECK_RESULT(validate_int32(c, _c[0], _c[1], _c[2], _c[3]))
+
+  IMM_2_ITER
+#undef TEST_IMPL
+
+  return TEST_SUCCESS;
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
 
 result_t test_vsudotq_lane_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
 
-result_t test_vusdotq_laneq_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+result_t test_vusdotq_laneq_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const uint8_t *_a = (uint8_t *)impl.test_cases_int_pointer1;
+  const int8_t *_b = (int8_t *)impl.test_cases_int_pointer2;
+  const int32_t *_r = (int32_t *)impl.test_cases_int_pointer3;
+  const int lane_num = 4;
+  int32_t _c[lane_num];
+  uint8x16_t a;
+  int8x16_t b;
+  int32x4_t r, c;
+
+#define TEST_IMPL(IDX)                         \
+  for (int i = 0; i < lane_num; i++) {         \
+    _c[i]=_r[i];                               \
+    for (int j = 0; j < 4; j++) {              \
+      _c[i] += (int32_t)_a[(i<<2)+j]*_b[(IDX<<2)+j]; \
+    }                                          \
+  }                                            \
+  a = vld1q_u8(_a);                            \
+  b = vld1q_s8(_b);                            \
+  r = vld1q_s32(_r);                           \
+  c = vusdotq_laneq_s32(r, a, b, IDX);         \
+  CHECK_RESULT(validate_int32(c, _c[0], _c[1], _c[2], _c[3]))
+
+  IMM_4_ITER
+#undef TEST_IMPL
+
+  return TEST_SUCCESS;
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
 
 result_t test_vsudotq_laneq_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
 
@@ -33102,13 +33594,67 @@ result_t test_vzip1q_s8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return 
 
 result_t test_vzip1_s16(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
 
-result_t test_vzip1q_s16(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+result_t test_vzip1q_s16(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const int16_t *_a = (int16_t *)impl.test_cases_int_pointer1;
+  const int16_t *_b = (int16_t *)impl.test_cases_int_pointer2;
+  const int half_lane_num = 4;
+  int16_t _c[half_lane_num * 2];
+  for (int i = 0; i < half_lane_num; i++) {
+    _c[2 * i] = _a[i];
+    _c[2 * i + 1] = _b[i];
+  }
+
+  int16x8_t a = vld1q_s16(_a);
+  int16x8_t b = vld1q_s16(_b);
+  int16x8_t c = vzip1q_s16(a, b);
+  return validate_int16(c, _c[0], _c[1], _c[2], _c[3], _c[4], _c[5], _c[6], _c[7]);
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
 
 result_t test_vzip1_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
 
-result_t test_vzip1q_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+result_t test_vzip1q_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const int32_t *_a = (int32_t *)impl.test_cases_int_pointer1;
+  const int32_t *_b = (int32_t *)impl.test_cases_int_pointer2;
+  const int half_lane_num = 2;
+  int32_t _c[half_lane_num * 2];
+  for (int i = 0; i < half_lane_num; i++) {
+    _c[2 * i] = _a[i];
+    _c[2 * i + 1] = _b[i];
+  }
 
-result_t test_vzip1q_s64(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+  int32x4_t a = vld1q_s32(_a);
+  int32x4_t b = vld1q_s32(_b);
+  int32x4_t c = vzip1q_s32(a, b);
+  return validate_int32(c, _c[0], _c[1], _c[2], _c[3]);
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
+
+result_t test_vzip1q_s64(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const int64_t *_a = (int64_t *)impl.test_cases_int_pointer1;
+  const int64_t *_b = (int64_t *)impl.test_cases_int_pointer2;
+  const int half_lane_num = 1;
+  int64_t _c[half_lane_num * 2];
+  for (int i = 0; i < half_lane_num; i++) {
+    _c[2 * i] = _a[i];
+    _c[2 * i + 1] = _b[i];
+  }
+
+  int64x2_t a = vld1q_s64(_a);
+  int64x2_t b = vld1q_s64(_b);
+  int64x2_t c = vzip1q_s64(a, b);
+  return validate_int64(c, _c[0], _c[1]);
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
 
 result_t test_vzip1_u8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
 
@@ -33152,7 +33698,25 @@ result_t test_vzip2_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return 
 
 result_t test_vzip2q_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
 
-result_t test_vzip2q_s64(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+result_t test_vzip2q_s64(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const int64_t *_a = (int64_t *)impl.test_cases_int_pointer1;
+  const int64_t *_b = (int64_t *)impl.test_cases_int_pointer2;
+  const int half_lane_num = 1;
+  int64_t _c[half_lane_num * 2];
+  for (int i = 0; i < half_lane_num; i++) {
+    _c[2 * i] = _a[i + half_lane_num];
+    _c[2 * i + 1] = _b[i + half_lane_num];
+  }
+
+  int64x2_t a = vld1q_s64(_a);
+  int64x2_t b = vld1q_s64(_b);
+  int64x2_t c = vzip2q_s64(a, b);
+  return validate_int64(c, _c[0], _c[1]);
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
 
 result_t test_vzip2_u8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
 
@@ -33194,13 +33758,50 @@ result_t test_vuzp1q_s16(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return
 
 result_t test_vuzp1_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
 
-result_t test_vuzp1q_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+result_t test_vuzp1q_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const int32_t *_a = (int32_t *)impl.test_cases_int_pointer1;
+  const int32_t *_b = (int32_t *)impl.test_cases_int_pointer2;
+  const int half_lane_num = 2;
+  int32_t _c[half_lane_num * 2];
+  for (int i = 0; i < half_lane_num; i++) {
+    _c[i] = _a[2 * i];
+    _c[i + half_lane_num] = _b[2 * i];
+  }
+
+  int32x4_t a = vld1q_s32(_a);
+  int32x4_t b = vld1q_s32(_b);
+  int32x4_t c = vuzp1q_s32(a, b);
+  return validate_int32(c, _c[0], _c[1], _c[2], _c[3]);
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
 
 result_t test_vuzp1q_s64(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
 
 result_t test_vuzp1_u8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
 
-result_t test_vuzp1q_u8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+result_t test_vuzp1q_u8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const uint8_t *_a = (uint8_t *)impl.test_cases_int_pointer1;
+  const uint8_t *_b = (uint8_t *)impl.test_cases_int_pointer2;
+  const int half_lane_num = 8;
+  uint8_t _c[half_lane_num * 2];
+  for (int i = 0; i < half_lane_num; i++) {
+    _c[i] = _a[2 * i];
+    _c[i + half_lane_num] = _b[2 * i];
+  }
+
+  uint8x16_t a = vld1q_u8(_a);
+  uint8x16_t b = vld1q_u8(_b);
+  uint8x16_t c = vuzp1q_u8(a, b);
+  return validate_uint8(c, _c[0], _c[1], _c[2], _c[3], _c[4], _c[5], _c[6], _c[7], _c[8],
+                        _c[9], _c[10], _c[11], _c[12], _c[13], _c[14], _c[15]);
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
 
 result_t test_vuzp1_u16(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
 
@@ -33284,11 +33885,59 @@ result_t test_vtrn1_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return 
 
 result_t test_vtrn1q_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
 
-result_t test_vtrn1q_s64(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+result_t test_vtrn1q_s64(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const int64_t *_a = (int64_t *)impl.test_cases_int_pointer1;
+  const int64_t *_b = (int64_t *)impl.test_cases_int_pointer2;
+  int64_t _c[2];
+  _c[0] = _a[0];
+  _c[1] = _b[0];
 
-result_t test_vtrn1_u8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+  int64x2_t a = vld1q_s64(_a);
+  int64x2_t b = vld1q_s64(_b);
+  int64x2_t c = vtrn1q_s64(a, b);
+  return validate_int64(c, _c[0], _c[1]);
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
 
-result_t test_vtrn1q_u8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+result_t test_vtrn1_u8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const uint8_t *_a = (uint8_t *)impl.test_cases_int_pointer1;
+  const uint8_t *_b = (uint8_t *)impl.test_cases_int_pointer2;
+  uint8_t _c[8];
+  for (int i = 0; i < 4; i++) {
+    _c[2*i] = _a[2*i];
+    _c[2*i + 1] = _b[2*i];
+  }
+  uint8x8_t a = vld1_u8(_a);
+  uint8x8_t b = vld1_u8(_b);
+  uint8x8_t c = vtrn1_u8(a, b);
+  return validate_uint8(c, _c[0], _c[1], _c[2], _c[3], _c[4], _c[5], _c[6], _c[7]);
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
+
+result_t test_vtrn1q_u8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const uint8_t *_a = (uint8_t *)impl.test_cases_int_pointer1;
+  const uint8_t *_b = (uint8_t *)impl.test_cases_int_pointer2;
+  uint8_t _c[16];
+  for (int i = 0; i < 8; i++) {
+    _c[2*i] = _a[2*i];
+    _c[2*i + 1] = _b[2*i];
+  }
+  uint8x16_t a = vld1q_u8(_a);
+  uint8x16_t b = vld1q_u8(_b);
+  uint8x16_t c = vtrn1q_u8(a, b);
+  return validate_uint8(c, _c[0], _c[1], _c[2], _c[3], _c[4], _c[5], _c[6], _c[7], _c[8], _c[9], _c[10], _c[11], _c[12],
+                        _c[13], _c[14], _c[15]);
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
 
 result_t test_vtrn1_u16(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
 
@@ -33298,7 +33947,22 @@ result_t test_vtrn1_u32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return 
 
 result_t test_vtrn1q_u32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
 
-result_t test_vtrn1q_u64(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+result_t test_vtrn1q_u64(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const uint64_t *_a = (uint64_t *)impl.test_cases_int_pointer1;
+  const uint64_t *_b = (uint64_t *)impl.test_cases_int_pointer1;
+  uint64_t _c[2];
+  _c[0] = _a[0];
+  _c[1] = _b[0];
+
+  uint64x2_t a = vld1q_u64(_a);
+  uint64x2_t b = vld1q_u64(_b);
+  uint64x2_t c = vtrn1q_u64(a, b);
+  return validate_uint64(c, _c[0], _c[1]);
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
 
 result_t test_vtrn1q_p64(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
 
@@ -33328,7 +33992,22 @@ result_t test_vtrn2_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return 
 
 result_t test_vtrn2q_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
 
-result_t test_vtrn2q_s64(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+result_t test_vtrn2q_s64(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const int64_t *_a = (int64_t *)impl.test_cases_int_pointer1;
+  const int64_t *_b = (int64_t *)impl.test_cases_int_pointer2;
+  int64_t _c[2];
+  _c[0] = _a[1];
+  _c[1] = _b[1];
+
+  int64x2_t a = vld1q_s64(_a);
+  int64x2_t b = vld1q_s64(_b);
+  int64x2_t c = vtrn2q_s64(a, b);
+  return validate_int64(c, _c[0], _c[1]);
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
 
 result_t test_vtrn2_u8(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
 
@@ -33342,7 +34021,22 @@ result_t test_vtrn2_u32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return 
 
 result_t test_vtrn2q_u32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
 
-result_t test_vtrn2q_u64(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+result_t test_vtrn2q_u64(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const uint64_t *_a = (uint64_t *)impl.test_cases_int_pointer1;
+  const uint64_t *_b = (uint64_t *)impl.test_cases_int_pointer1;
+  uint64_t _c[2];
+  _c[0] = _a[1];
+  _c[1] = _b[1];
+
+  uint64x2_t a = vld1q_u64(_a);
+  uint64x2_t b = vld1q_u64(_b);
+  uint64x2_t c = vtrn2q_u64(a, b);
+  return validate_uint64(c, _c[0], _c[1]);
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
 
 result_t test_vtrn2q_p64(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
 
@@ -42958,7 +43652,16 @@ result_t test_vld1q_u8_x2(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { retur
 
 result_t test_vld1_u16_x2(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
 
-result_t test_vld1q_u16_x2(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+result_t test_vld1q_u16_x2(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const uint16_t *_a = (uint16_t *)impl.test_cases_int_pointer1;
+  uint16x8x2_t c = vld1q_u16_x2(_a);
+  return validate_uint16(c, _a[0], _a[1], _a[2], _a[3], _a[4], _a[5], _a[6], _a[7], _a[8], _a[9], _a[10], _a[11], _a[12],
+                        _a[13], _a[14], _a[15]);
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
 
 result_t test_vld1_u32_x2(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
 

--- a/tests/impl.h
+++ b/tests/impl.h
@@ -905,18 +905,18 @@
   _(vaddv_f32)                                                                   \
   _(vaddvq_f32)                                                                  \
   _(vaddvq_f64)                                                                  \
-  /*_(vaddlv_s8)                                                              */ \
-  /*_(vaddlvq_s8)                                                             */ \
-  /*_(vaddlv_s16)                                                             */ \
-  /*_(vaddlvq_s16)                                                            */ \
-  /*_(vaddlv_s32)                                                             */ \
-  /*_(vaddlvq_s32)                                                            */ \
-  /*_(vaddlv_u8)                                                              */ \
-  /*_(vaddlvq_u8)                                                             */ \
-  /*_(vaddlv_u16)                                                             */ \
-  /*_(vaddlvq_u16)                                                            */ \
-  /*_(vaddlv_u32)                                                             */ \
-  /*_(vaddlvq_u32)                                                            */ \
+  _(vaddlv_s8)                                                                   \
+  _(vaddlvq_s8)                                                                  \
+  _(vaddlv_s16)                                                                  \
+  _(vaddlvq_s16)                                                                 \
+  _(vaddlv_s32)                                                                  \
+  _(vaddlvq_s32)                                                                 \
+  _(vaddlv_u8)                                                                   \
+  _(vaddlvq_u8)                                                                  \
+  _(vaddlv_u16)                                                                  \
+  _(vaddlvq_u16)                                                                 \
+  _(vaddlv_u32)                                                                  \
+  _(vaddlvq_u32)                                                                 \
   _(vmaxv_s8)                                                                    \
   _(vmaxvq_s8)                                                                   \
   _(vmaxv_s16)                                                                   \
@@ -1836,9 +1836,9 @@
   _(vtbx4_u8)                                                                    \
   /*_(vtbx4_p8)                                                               */ \
   /*_(vqtbl1_s8)                                                              */ \
-  /*_(vqtbl1q_s8)                                                             */ \
-  /*_(vqtbl1_u8)                                                              */ \
-  /*_(vqtbl1q_u8)                                                             */ \
+  _(vqtbl1q_s8)                                                                  \
+  _(vqtbl1_u8)                                                                   \
+  _(vqtbl1q_u8)                                                                  \
   /*_(vqtbl1_p8)                                                              */ \
   /*_(vqtbl1q_p8)                                                             */ \
   /*_(vqtbx1_s8)                                                              */ \
@@ -1848,21 +1848,21 @@
   /*_(vqtbx1_p8)                                                              */ \
   /*_(vqtbx1q_p8)                                                             */ \
   /*_(vqtbl2_s8)                                                              */ \
-  /*_(vqtbl2q_s8)                                                             */ \
-  /*_(vqtbl2_u8)                                                              */ \
-  /*_(vqtbl2q_u8)                                                             */ \
+  _(vqtbl2q_s8)                                                                  \
+  _(vqtbl2_u8)                                                                   \
+  _(vqtbl2q_u8)                                                                  \
   /*_(vqtbl2_p8)                                                              */ \
   /*_(vqtbl2q_p8)                                                             */ \
   /*_(vqtbl3_s8)                                                              */ \
   /*_(vqtbl3q_s8)                                                             */ \
   /*_(vqtbl3_u8)                                                              */ \
-  /*_(vqtbl3q_u8)                                                             */ \
+  _(vqtbl3q_u8)                                                                  \
   /*_(vqtbl3_p8)                                                              */ \
   /*_(vqtbl3q_p8)                                                             */ \
   /*_(vqtbl4_s8)                                                              */ \
   /*_(vqtbl4q_s8)                                                             */ \
   /*_(vqtbl4_u8)                                                              */ \
-  /*_(vqtbl4q_u8)                                                             */ \
+  _(vqtbl4q_u8)                                                                  \
   /*_(vqtbl4_p8)                                                              */ \
   /*_(vqtbl4q_p8)                                                             */ \
   /*_(vqtbx2_s8)                                                              */ \
@@ -2317,12 +2317,12 @@
   /*_(vzip1_s8)                                                               */ \
   /*_(vzip1q_s8)                                                              */ \
   /*_(vzip1_s16)                                                              */ \
-  /*_(vzip1q_s16)                                                             */ \
+  _(vzip1q_s16)                                                                  \
   /*_(vzip1_s32)                                                              */ \
-  /*_(vzip1q_s32)                                                             */ \
-  /*_(vzip1q_s64)                                                             */ \
+  _(vzip1q_s32)                                                                  \
+  _(vzip1q_s64)                                                                  \
   /*_(vzip1_u8)                                                               */ \
-  /*_(vzip1q_u8)                                                              */ \
+  _(vzip1q_u8)                                                                   \
   /*_(vzip1_u16)                                                              */ \
   /*_(vzip1q_u16)                                                             */ \
   /*_(vzip1_u32)                                                              */ \
@@ -2342,7 +2342,7 @@
   /*_(vzip2q_s16)                                                             */ \
   /*_(vzip2_s32)                                                              */ \
   /*_(vzip2q_s32)                                                             */ \
-  /*_(vzip2q_s64)                                                             */ \
+  _(vzip2q_s64)                                                                  \
   /*_(vzip2_u8)                                                               */ \
   /*_(vzip2q_u8)                                                              */ \
   /*_(vzip2_u16)                                                              */ \
@@ -2363,7 +2363,7 @@
   /*_(vuzp1_s16)                                                              */ \
   /*_(vuzp1q_s16)                                                             */ \
   /*_(vuzp1_s32)                                                              */ \
-  /*_(vuzp1q_s32)                                                             */ \
+  _(vuzp1q_s32)                                                                  \
   /*_(vuzp1q_s64)                                                             */ \
   /*_(vuzp1_u8)                                                               */ \
   /*_(vuzp1q_u8)                                                              */ \
@@ -2408,14 +2408,14 @@
   /*_(vtrn1q_s16)                                                             */ \
   /*_(vtrn1_s32)                                                              */ \
   /*_(vtrn1q_s32)                                                             */ \
-  /*_(vtrn1q_s64)                                                             */ \
-  /*_(vtrn1_u8)                                                               */ \
-  /*_(vtrn1q_u8)                                                              */ \
+  _(vtrn1q_s64)                                                                  \
+  _(vtrn1_u8)                                                                    \
+  _(vtrn1q_u8)                                                                   \
   /*_(vtrn1_u16)                                                              */ \
   /*_(vtrn1q_u16)                                                             */ \
   /*_(vtrn1_u32)                                                              */ \
   /*_(vtrn1q_u32)                                                             */ \
-  /*_(vtrn1q_u64)                                                             */ \
+  _(vtrn1q_u64)                                                                  \
   /*_(vtrn1q_p64)                                                             */ \
   /*_(vtrn1_f32)                                                              */ \
   /*_(vtrn1q_f32)                                                             */ \
@@ -2430,14 +2430,14 @@
   /*_(vtrn2q_s16)                                                             */ \
   /*_(vtrn2_s32)                                                              */ \
   /*_(vtrn2q_s32)                                                             */ \
-  /*_(vtrn2q_s64)                                                             */ \
+  _(vtrn2q_s64)                                                                  \
   /*_(vtrn2_u8)                                                               */ \
   /*_(vtrn2q_u8)                                                              */ \
   /*_(vtrn2_u16)                                                              */ \
   /*_(vtrn2q_u16)                                                             */ \
   /*_(vtrn2_u32)                                                              */ \
   /*_(vtrn2q_u32)                                                             */ \
-  /*_(vtrn2q_u64)                                                             */ \
+  _(vtrn2q_u64)                                                                  \
   /*_(vtrn2q_p64)                                                             */ \
   /*_(vtrn2_f32)                                                              */ \
   /*_(vtrn2q_f32)                                                             */ \
@@ -3237,7 +3237,7 @@
   /*_(vld1_u8_x2)                                                             */ \
   /*_(vld1q_u8_x2)                                                            */ \
   /*_(vld1_u16_x2)                                                            */ \
-  /*_(vld1q_u16_x2)                                                           */ \
+  _(vld1q_u16_x2)                                                                \
   /*_(vld1_u32_x2)                                                            */ \
   /*_(vld1q_u32_x2)                                                           */ \
   /*_(vld1_f16_x2)                                                            */ \
@@ -4058,14 +4058,14 @@
   /*_(vzip_f16)                                                               */ \
   /*_(vzipq_f16)                                                              */ \
   /* AdvSIMD Dot Product intrinsics. */                                          \
-  /*_(vdot_u32)                                                               */ \
-  /*_(vdotq_u32)                                                              */ \
+  _(vdot_u32)                                                                    \
+  _(vdotq_u32)                                                                   \
   /*_(vdot_s32)                                                               */ \
   /*_(vdotq_s32)                                                              */ \
   /*_(vdot_lane_u32)                                                          */ \
   /*_(vdotq_lane_u32)                                                         */ \
   /*_(vdot_lane_s32)                                                          */ \
-  /*_(vdotq_lane_s32)                                                         */ \
+  _(vdotq_lane_s32)                                                              \
   /*_(vsha512hq_u64)                                                          */ \
   /*_(vsha512h2q_u64)                                                         */ \
   /*_(vsha512su0q_u64)                                                        */ \
@@ -4100,7 +4100,7 @@
   /*_(vdot_laneq_u32)                                                         */ \
   /*_(vdotq_laneq_u32)                                                        */ \
   /*_(vdot_laneq_s32)                                                         */ \
-  /*_(vdotq_laneq_s32)                                                        */ \
+  _(vdotq_laneq_s32)                                                             \
   /*_(vfmlal_low_f16)                                                         */ \
   /*_(vfmlsl_low_f16)                                                         */ \
   /*_(vfmlal_high_f16)                                                        */ \
@@ -4209,13 +4209,13 @@
   /*_(vusmmlaq_s32)                                                           */ \
   /* AdvSIMD Matrix Multiply-Accumulate and Dot Product intrinsics. */           \
   /*_(vusdot_s32)                                                             */ \
-  /*_(vusdotq_s32)                                                            */ \
+  _(vusdotq_s32)                                                                 \
   /*_(vusdot_lane_s32)                                                        */ \
-  /*_(vusdotq_lane_s32)                                                       */ \
+  _(vusdotq_lane_s32)                                                            \
   /*_(vsudot_lane_s32)                                                        */ \
   /*_(vsudotq_lane_s32)                                                       */ \
   /*_(vusdot_laneq_s32)                                                       */ \
-  /*_(vusdotq_laneq_s32)                                                      */ \
+  _(vusdotq_laneq_s32)                                                           \
   /*_(vsudot_laneq_s32)                                                       */ \
   /*_(vsudotq_laneq_s32)                                                      */ \
   /*_(vcreate_bf16)                                                           */ \


### PR DESCRIPTION
Hello, noticed some tests are failing when running with vlen>128-bits. Errors produced by the fact that larger vector lengths introduce elements in the registers which wouldn't be seen on vlen=128-bits(which naturally matches Neon).
Fixed implementations - wrapping _vrgather_ with a _vmerge_ to set values out of bounds to 0 for _vtbl_, properly sliding elements for _vzip_.

Additionally implemented a couple of intrinsics I was interested from: vaddlv, vqtbl, vld1, vtrn, vzip, vuzp, vdot - sorry I have not covered the entire groups.