### PR TITLE
test: Build tests on ARM with armv8.6-a flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ endif
 
 ifndef CROSS_COMPILE
     processor := $(shell uname -m)
+	ARCH_CFLAGS = -march=armv8.6-a
 else # CROSS_COMPILE was set
     CC = $(CROSS_COMPILE)gcc
     CXX = $(CROSS_COMPILE)g++


### PR DESCRIPTION
To pass the tests on arm and support vdot* intrinsics, we build tests with ARCH_CFLAGS = -march=armv8.6-a which support vdot*