### PR TITLE
test: Revert to qemu image to support vdot*

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -29,29 +29,30 @@ jobs:
 
   # for validate test cases only
   check_test_cases:
-    runs-on: macos-14
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        arch: [aarch64]
+        cxx_compiler: [g++-10, clang++-11]
     steps:
       - name: checkout code
         uses: actions/checkout@v3.2.0
       - name: build artifact
-        run: |
-          export ENABLE_TEST_ALL=true
-          make test
-  check_test_cases_gcc:
-    runs-on: macos-14
-    steps:
-      - name: checkout code
-        uses: actions/checkout@v3.2.0
-      - name: install gcc
-        run: |
-          brew update
-          brew install gcc@12
-      - name: build artifact
-        run: |
-          export CC=gcc-12
-          export CXX=g++-12
-          export ENABLE_TEST_ALL=true
-          make test
+        # The Github Action for non-x86 CPU
+        # https://github.com/uraimo/run-on-arch-action
+        uses: uraimo/run-on-arch-action@v2.5.0
+        with:
+          arch: ${{ matrix.arch }}
+          distro: ubuntu20.04
+          env: |
+            CXX: ${{ matrix.cxx_compiler }}
+          install: |
+            apt-get update -q -y
+            apt-get install -q -y "${{ matrix.cxx_compiler }}" make
+            apt-get install -q -y gcc
+          run: |
+            export ENABLE_TEST_ALL=true
+            make test
 
   coding_style:
     runs-on: ubuntu-22.04

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ endif
 
 ifndef CROSS_COMPILE
     processor := $(shell uname -m)
-	ARCH_CFLAGS = -march=armv8.6-a
+	ARCH_CFLAGS = -march=armv8.4-a+simd+i8mm+dotprod
 else # CROSS_COMPILE was set
     CC = $(CROSS_COMPILE)gcc
     CXX = $(CROSS_COMPILE)g++


### PR DESCRIPTION
Github Action Arm-based hosts don't support vdot*. So revert back to qemu image to run the tests