### PR TITLE
ci: add arm-neon-tests suite as a submodule and GitHub Actions job

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -85,5 +85,5 @@ jobs:
         # clang-format version should be set
         run: |
             sudo apt-get install -q -y clang-format
-            sh scripts/check-format.sh
+            bash scripts/check-format.sh
         shell: bash

--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v3.2.0
+        with:
+          submodules: recursive
       - name: setup riscv toolchain
         run: |
           mkdir /opt/riscv
@@ -26,6 +28,26 @@ jobs:
           export SIMULATOR_TYPE=qemu
           export ENABLE_TEST_ALL=true
           sh scripts/cross-test.sh
+
+  # run arm-neon-tests suite against neon2rvv
+  arm_neon_tests:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v3.2.0
+        with:
+          submodules: recursive
+      - name: setup riscv toolchain
+        run: |
+          mkdir /opt/riscv
+          export PATH=$PATH:/opt/riscv/bin
+          wget https://github.com/howjmay/prebuilt-riscv-spike/releases/download/latest/riscv.tar.gz
+          sudo tar -xzf riscv.tar.gz -C /opt/
+
+      - name: build and check arm-neon-tests
+        run: |
+          export PATH=$PATH:/opt/riscv/bin
+          make CROSS_COMPILE=riscv64-unknown-elf- SIMULATOR_TYPE=qemu check-arm-neon-tests
 
   # for validate test cases only
   check_test_cases:

--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -55,17 +55,17 @@ jobs:
     strategy:
       matrix:
         arch: [aarch64]
-        cxx_compiler: [g++-10, clang++-11]
+        cxx_compiler: [g++-12, clang++-14]
     steps:
       - name: checkout code
         uses: actions/checkout@v3.2.0
       - name: build artifact
         # The Github Action for non-x86 CPU
         # https://github.com/uraimo/run-on-arch-action
-        uses: uraimo/run-on-arch-action@v2.5.0
+        uses: uraimo/run-on-arch-action@v3.0.1
         with:
           arch: ${{ matrix.arch }}
-          distro: ubuntu20.04
+          distro: ubuntu22.04
           env: |
             CXX: ${{ matrix.cxx_compiler }}
           install: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tests/arm-neon-tests"]
+	path = tests/arm-neon-tests
+	url = https://github.com/christophe-lyon/arm-neon-tests

--- a/Makefile
+++ b/Makefile
@@ -82,10 +82,46 @@ format:
 	@if ! hash clang-format; then echo "clang-format is required to indent"; fi
 	clang-format -i neon2rvv.h tests/*.cpp tests/*.h
 
-.PHONY: clean check format
+# ── arm-neon-tests integration ──────────────────────────────────────────────
+# Tests from https://github.com/christophe-lyon/arm-neon-tests compiled
+# against neon2rvv and compared with the upstream reference output.
+ANT_DIR = tests/arm-neon-tests
+
+# All ref_*.c files except the non-NEON (integer/DSP) ones not covered by
+# neon2rvv. Those are replaced by empty stubs in tests/neon_stubs.c.
+ANT_SRCS := $(filter-out \
+	$(ANT_DIR)/ref_integer.c \
+	$(ANT_DIR)/ref_dsp.c \
+	$(ANT_DIR)/ref_dspfns.c, \
+	$(wildcard $(ANT_DIR)/ref_*.c))
+
+ANT_CFLAGS  = -Wall -Wno-unused-variable -Wno-unused-function \
+              -ffast-math $(ARCH_CFLAGS) \
+              -I. -Itests -I$(ANT_DIR)
+ANT_REFFILE     = neon2rvv-neon-ref.txt
+ANT_GCCTESTFILE = neon2rvv-gcc-tests.txt
+ANT_EXEC        = tests/arm-neon-tests-main
+
+$(ANT_EXEC): $(ANT_SRCS) tests/neon_stubs.c
+	$(CC) $(ANT_CFLAGS) -static \
+	    -DREFFILE=\"$(ANT_REFFILE)\" \
+	    -DGCCTESTS_FILE=\"$(ANT_GCCTESTFILE)\" \
+	    -o $@ \
+	    $(ANT_DIR)/compute_ref.c $(ANT_SRCS) tests/neon_stubs.c -lm
+
+# Build only (no run) – useful to verify the code compiles on RISC-V.
+build-arm-neon-tests: $(ANT_EXEC)
+
+# Build, run, and diff against the upstream reference.
+check-arm-neon-tests: $(ANT_EXEC)
+	$(SIMULATOR) $(SIMULATOR_FLAGS) $(PROXY_KERNEL) $<
+	diff $(ANT_REFFILE) $(ANT_DIR)/ref-rvct-neon-nofp16.txt
+
+.PHONY: clean check format build-arm-neon-tests check-arm-neon-tests
 
 clean:
 	$(RM) $(OBJS) $(EXEC) $(deps) neon2rvv.h.gch
+	$(RM) $(ANT_EXEC) $(ANT_REFFILE) $(ANT_GCCTESTFILE)
 
 clean-all: clean
 	$(RM) *.log

--- a/Makefile
+++ b/Makefile
@@ -87,12 +87,21 @@ format:
 # against neon2rvv and compared with the upstream reference output.
 ANT_DIR = tests/arm-neon-tests
 
-# All ref_*.c files except the non-NEON (integer/DSP) ones not covered by
-# neon2rvv. Those are replaced by empty stubs in tests/neon_stubs.c.
+# All ref_*.c files except:
+#  - non-NEON (integer/DSP) stubs replaced by tests/neon_stubs.c
+#  - template files that lack an INSN_NAME guard and are only meant to be
+#    #include-d by the actual per-intrinsic ref_v*.c files
 ANT_SRCS := $(filter-out \
 	$(ANT_DIR)/ref_integer.c \
 	$(ANT_DIR)/ref_dsp.c \
-	$(ANT_DIR)/ref_dspfns.c, \
+	$(ANT_DIR)/ref_dspfns.c \
+	$(ANT_DIR)/ref_v_binary_op.c \
+	$(ANT_DIR)/ref_v_binary_sat_op.c \
+	$(ANT_DIR)/ref_v_comp_f_op.c \
+	$(ANT_DIR)/ref_v_comp_op.c \
+	$(ANT_DIR)/ref_v_unary_op.c \
+	$(ANT_DIR)/ref_v_unary_sat_op.c \
+	$(ANT_DIR)/ref_vsXi_n.c, \
 	$(wildcard $(ANT_DIR)/ref_*.c))
 
 ANT_CFLAGS  = -Wall -Wno-unused-variable -Wno-unused-function \

--- a/neon2rvv.h
+++ b/neon2rvv.h
@@ -7076,13 +7076,13 @@ FORCE_INLINE uint64x2_t vsriq_n_u64(uint64x2_t a, uint64x2_t b, const int c) {
 
 // FORCE_INLINE poly64x2_t vsriq_n_p64(poly64x2_t a, poly64x2_t b, const int n);
 
-// FORCE_INLINE poly8x8_t vsri_n_p8(poly8x8_t a, poly8x8_t b, const int n);
+FORCE_INLINE poly8x8_t vsri_n_p8(poly8x8_t a, poly8x8_t b, const int n) { return vsri_n_u8(a, b, n); }
 
-// FORCE_INLINE poly8x16_t vsriq_n_p8(poly8x16_t a, poly8x16_t b, const int n);
+FORCE_INLINE poly8x16_t vsriq_n_p8(poly8x16_t a, poly8x16_t b, const int n) { return vsriq_n_u8(a, b, n); }
 
-// FORCE_INLINE poly16x4_t vsri_n_p16(poly16x4_t a, poly16x4_t b, const int n);
+FORCE_INLINE poly16x4_t vsri_n_p16(poly16x4_t a, poly16x4_t b, const int n) { return vsri_n_u16(a, b, n); }
 
-// FORCE_INLINE poly16x8_t vsriq_n_p16(poly16x8_t a, poly16x8_t b, const int n);
+FORCE_INLINE poly16x8_t vsriq_n_p16(poly16x8_t a, poly16x8_t b, const int n) { return vsriq_n_u16(a, b, n); }
 
 FORCE_INLINE int64_t vsrid_n_s64(int64_t a, int64_t b, const int n) {
   if (n == 64) {
@@ -7236,13 +7236,13 @@ FORCE_INLINE uint64x2_t vsliq_n_u64(uint64x2_t a, uint64x2_t b, const int c) {
 
 // FORCE_INLINE poly64x2_t vsliq_n_p64(poly64x2_t a, poly64x2_t b, const int n);
 
-// FORCE_INLINE poly8x8_t vsli_n_p8(poly8x8_t a, poly8x8_t b, const int n);
+FORCE_INLINE poly8x8_t vsli_n_p8(poly8x8_t a, poly8x8_t b, const int n) { return vsli_n_u8(a, b, n); }
 
-// FORCE_INLINE poly8x16_t vsliq_n_p8(poly8x16_t a, poly8x16_t b, const int n);
+FORCE_INLINE poly8x16_t vsliq_n_p8(poly8x16_t a, poly8x16_t b, const int n) { return vsliq_n_u8(a, b, n); }
 
-// FORCE_INLINE poly16x4_t vsli_n_p16(poly16x4_t a, poly16x4_t b, const int n);
+FORCE_INLINE poly16x4_t vsli_n_p16(poly16x4_t a, poly16x4_t b, const int n) { return vsli_n_u16(a, b, n); }
 
-// FORCE_INLINE poly16x8_t vsliq_n_p16(poly16x8_t a, poly16x8_t b, const int n);
+FORCE_INLINE poly16x8_t vsliq_n_p16(poly16x8_t a, poly16x8_t b, const int n) { return vsliq_n_u16(a, b, n); }
 
 FORCE_INLINE int64_t vslid_n_s64(int64_t a, int64_t b, const int n) {
   if (n == 64) {
@@ -7849,13 +7849,13 @@ FORCE_INLINE int32x4_t vdupq_n_s32(int32_t a) { return __riscv_vmv_v_x_i32m1(a, 
 
 FORCE_INLINE float32x4_t vdupq_n_f32(float32_t a) { return __riscv_vfmv_v_f_f32m1(a, 4); }
 
-// FORCE_INLINE poly8x8_t vdup_n_p8(poly8_t value);
+FORCE_INLINE poly8x8_t vdup_n_p8(poly8_t value) { return vdup_n_u8(value); }
 
-// FORCE_INLINE poly8x16_t vdupq_n_p8(poly8_t value);
+FORCE_INLINE poly8x16_t vdupq_n_p8(poly8_t value) { return vdupq_n_u8(value); }
 
-// FORCE_INLINE poly16x4_t vdup_n_p16(poly16_t value);
+FORCE_INLINE poly16x4_t vdup_n_p16(poly16_t value) { return vdup_n_u16(value); }
 
-// FORCE_INLINE poly16x8_t vdupq_n_p16(poly16_t value);
+FORCE_INLINE poly16x8_t vdupq_n_p16(poly16_t value) { return vdupq_n_u16(value); }
 
 FORCE_INLINE float64x1_t vdup_n_f64(float64_t a) { return __riscv_vfmv_v_f_f64m1(a, 1); }
 
@@ -7901,13 +7901,13 @@ FORCE_INLINE int32x4_t vmovq_n_s32(int32_t a) { return vdupq_n_s32(a); }
 
 FORCE_INLINE float32x4_t vmovq_n_f32(float32_t a) { return vdupq_n_f32(a); }
 
-// FORCE_INLINE poly8x8_t vmov_n_p8(poly8_t value);
+FORCE_INLINE poly8x8_t vmov_n_p8(poly8_t value) { return vdup_n_p8(value); }
 
-// FORCE_INLINE poly8x16_t vmovq_n_p8(poly8_t value);
+FORCE_INLINE poly8x16_t vmovq_n_p8(poly8_t value) { return vdupq_n_p8(value); }
 
-// FORCE_INLINE poly16x4_t vmov_n_p16(poly16_t value);
+FORCE_INLINE poly16x4_t vmov_n_p16(poly16_t value) { return vdup_n_p16(value); }
 
-// FORCE_INLINE poly16x8_t vmovq_n_p16(poly16_t value);
+FORCE_INLINE poly16x8_t vmovq_n_p16(poly16_t value) { return vdupq_n_p16(value); }
 
 FORCE_INLINE float64x1_t vmov_n_f64(float64_t a) { return vdup_n_f64(a); }
 
@@ -8686,7 +8686,7 @@ FORCE_INLINE uint8x8_t vtbl1_u8(uint8x8_t a, uint8x8_t b) {
   return __riscv_vmerge_vxm_u8m1(__riscv_vrgather_vv_u8m1(a, b, 8), 0, mask, 8);
 }
 
-// FORCE_INLINE poly8x8_t vtbl1_p8(poly8x8_t a, uint8x8_t idx);
+FORCE_INLINE poly8x8_t vtbl1_p8(poly8x8_t a, uint8x8_t idx) { return vtbl1_u8(a, idx); }
 
 FORCE_INLINE int8x8_t vtbl2_s8(int8x8x2_t a, int8x8_t b) {
   vint8m1_t table1 = __riscv_vget_v_i8m1x2_i8m1(a, 0);
@@ -8704,7 +8704,7 @@ FORCE_INLINE uint8x8_t vtbl2_u8(uint8x8x2_t a, uint8x8_t b) {
   return __riscv_vmerge_vxm_u8m1(__riscv_vrgather_vv_u8m1(table, b, 8), 0, mask, 8);
 }
 
-// FORCE_INLINE poly8x8_t vtbl2_p8(poly8x8x2_t a, uint8x8_t idx);
+FORCE_INLINE poly8x8_t vtbl2_p8(poly8x8x2_t a, uint8x8_t idx) { return vtbl2_u8(a, idx); }
 
 FORCE_INLINE int8x8_t vtbl3_s8(int8x8x3_t a, int8x8_t b) {
   vint8m1_t table1 = __riscv_vget_v_i8m1x3_i8m1(a, 0);
@@ -8732,7 +8732,7 @@ FORCE_INLINE uint8x8_t vtbl3_u8(uint8x8x3_t a, uint8x8_t b) {
   return __riscv_vmerge_vxm_u8m1(gather, 0, mask, 8);
 }
 
-// FORCE_INLINE poly8x8_t vtbl3_p8(poly8x8x3_t a, uint8x8_t idx);
+FORCE_INLINE poly8x8_t vtbl3_p8(poly8x8x3_t a, uint8x8_t idx) { return vtbl3_u8(a, idx); }
 
 FORCE_INLINE int8x8_t vtbl4_s8(int8x8x4_t a, int8x8_t b) {
   vint8m1_t table1 = __riscv_vget_v_i8m1x4_i8m1(a, 0);
@@ -8762,7 +8762,7 @@ FORCE_INLINE uint8x8_t vtbl4_u8(uint8x8x4_t a, uint8x8_t b) {
   return __riscv_vmerge_vxm_u8m1(gather, 0, mask, 8);
 }
 
-// FORCE_INLINE poly8x8_t vtbl4_p8(poly8x8x4_t a, uint8x8_t idx);
+FORCE_INLINE poly8x8_t vtbl4_p8(poly8x8x4_t a, uint8x8_t idx) { return vtbl4_u8(a, idx); }
 
 FORCE_INLINE int8x8_t vtbx1_s8(int8x8_t a, int8x8_t b, int8x8_t c) {
   vint8m1_t b_s = __riscv_vslideup_vx_i8m1(b, vdup_n_s8(0), 8, 16);
@@ -8782,7 +8782,7 @@ FORCE_INLINE uint8x8_t vtbx1_u8(uint8x8_t a, uint8x8_t b, uint8x8_t c) {
   return __riscv_vmerge_vvm_u8m1(b_scatter, a, out_range_mask, 8);
 }
 
-// FORCE_INLINE poly8x8_t vtbx1_p8(poly8x8_t a, poly8x8_t b, uint8x8_t idx);
+FORCE_INLINE poly8x8_t vtbx1_p8(poly8x8_t a, poly8x8_t b, uint8x8_t idx) { return vtbx1_u8(a, b, idx); }
 
 FORCE_INLINE int8x8_t vtbx2_s8(int8x8_t a, int8x8x2_t b, int8x8_t c) {
   vint8m1_t table1 = __riscv_vget_v_i8m1x2_i8m1(b, 0);
@@ -8806,7 +8806,7 @@ FORCE_INLINE uint8x8_t vtbx2_u8(uint8x8_t a, uint8x8x2_t b, uint8x8_t c) {
   return __riscv_vmerge_vvm_u8m1(b_scatter, a, out_range_mask, 16);
 }
 
-// FORCE_INLINE poly8x8_t vtbx2_p8(poly8x8_t a, poly8x8x2_t b, uint8x8_t idx);
+FORCE_INLINE poly8x8_t vtbx2_p8(poly8x8_t a, poly8x8x2_t b, uint8x8_t idx) { return vtbx2_u8(a, b, idx); }
 
 FORCE_INLINE int8x8_t vtbx3_s8(int8x8_t a, int8x8x3_t b, int8x8_t c) {
   vint8m1_t table1 = __riscv_vget_v_i8m1x3_i8m1(b, 0);
@@ -8836,7 +8836,7 @@ FORCE_INLINE uint8x8_t vtbx3_u8(uint8x8_t a, uint8x8x3_t b, uint8x8_t c) {
   return __riscv_vmerge_vvm_u8m1(b_scatter, a, out_range_mask, 8);
 }
 
-// FORCE_INLINE poly8x8_t vtbx3_p8(poly8x8_t a, poly8x8x3_t b, uint8x8_t idx);
+FORCE_INLINE poly8x8_t vtbx3_p8(poly8x8_t a, poly8x8x3_t b, uint8x8_t idx) { return vtbx3_u8(a, b, idx); }
 
 FORCE_INLINE int8x8_t vtbx4_s8(int8x8_t a, int8x8x4_t b, int8x8_t c) {
   vint8m1_t table1 = __riscv_vget_v_i8m1x4_i8m1(b, 0);
@@ -8870,7 +8870,7 @@ FORCE_INLINE uint8x8_t vtbx4_u8(uint8x8_t a, uint8x8x4_t b, uint8x8_t c) {
   return __riscv_vmerge_vvm_u8m1(b_scatter, a, out_range_mask, 8);
 }
 
-// FORCE_INLINE poly8x8_t vtbx4_p8(poly8x8_t a, poly8x8x4_t b, uint8x8_t idx);
+FORCE_INLINE poly8x8_t vtbx4_p8(poly8x8_t a, poly8x8x4_t b, uint8x8_t idx) { return vtbx4_u8(a, b, idx); }
 
 // FORCE_INLINE int8x8_t vqtbl1_s8(int8x16_t t, uint8x8_t idx);
 
@@ -12807,9 +12807,9 @@ FORCE_INLINE uint16x4x2_t vtrn_u16(uint16x4_t a, uint16x4_t b) {
   return __riscv_vcreate_v_u16m1x2(trn1, trn2);
 }
 
-// FORCE_INLINE poly8x8x2_t vtrn_p8(poly8x8_t a, poly8x8_t b);
+FORCE_INLINE poly8x8x2_t vtrn_p8(poly8x8_t a, poly8x8_t b) { return vtrn_u8(a, b); }
 
-// FORCE_INLINE poly16x4x2_t vtrn_p16(poly16x4_t a, poly16x4_t b);
+FORCE_INLINE poly16x4x2_t vtrn_p16(poly16x4_t a, poly16x4_t b) { return vtrn_u16(a, b); }
 
 FORCE_INLINE int32x2x2_t vtrn_s32(int32x2_t a, int32x2_t b) {
   vuint64m1_t a_u64 = __riscv_vreinterpret_v_i64m1_u64m1(__riscv_vreinterpret_v_i32m1_i64m1(a));
@@ -12971,9 +12971,9 @@ FORCE_INLINE uint32x4x2_t vtrnq_u32(uint32x4_t a, uint32x4_t b) {
   return __riscv_vcreate_v_u32m1x2(trn1, trn2);
 }
 
-// FORCE_INLINE poly8x16x2_t vtrnq_p8(poly8x16_t a, poly8x16_t b);
+FORCE_INLINE poly8x16x2_t vtrnq_p8(poly8x16_t a, poly8x16_t b) { return vtrnq_u8(a, b); }
 
-// FORCE_INLINE poly16x8x2_t vtrnq_p16(poly16x8_t a, poly16x8_t b);
+FORCE_INLINE poly16x8x2_t vtrnq_p16(poly16x8_t a, poly16x8_t b) { return vtrnq_u16(a, b); }
 
 FORCE_INLINE int8x8x2_t vzip_s8(int8x8_t a, int8x8_t b) {
   // TODO add explaination. source:
@@ -13009,9 +13009,9 @@ FORCE_INLINE uint16x4x2_t vzip_u16(uint16x4_t a, uint16x4_t b) {
   return __riscv_vcreate_v_u16m1x2(zip, __riscv_vslidedown_vx_u16m1(zip, 4, 8));
 }
 
-// FORCE_INLINE poly8x8x2_t vzip_p8(poly8x8_t a, poly8x8_t b);
+FORCE_INLINE poly8x8x2_t vzip_p8(poly8x8_t a, poly8x8_t b) { return vzip_u8(a, b); }
 
-// FORCE_INLINE poly16x4x2_t vzip_p16(poly16x4_t a, poly16x4_t b);
+FORCE_INLINE poly16x4x2_t vzip_p16(poly16x4_t a, poly16x4_t b) { return vzip_u16(a, b); }
 
 FORCE_INLINE int32x2x2_t vzip_s32(int32x2_t a, int32x2_t b) {
   vuint32m1_t a_u32 = __riscv_vreinterpret_v_i32m1_u32m1(a);
@@ -13103,9 +13103,9 @@ FORCE_INLINE uint32x4x2_t vzipq_u32(uint32x4_t a, uint32x4_t b) {
                                    __riscv_vget_v_u32m2_u32m1(__riscv_vslidedown_vx_u32m2(zip, 4, 8), 0));
 }
 
-// FORCE_INLINE poly8x16x2_t vzipq_p8(poly8x16_t a, poly8x16_t b);
+FORCE_INLINE poly8x16x2_t vzipq_p8(poly8x16_t a, poly8x16_t b) { return vzipq_u8(a, b); }
 
-// FORCE_INLINE poly16x8x2_t vzipq_p16(poly16x8_t a, poly16x8_t b);
+FORCE_INLINE poly16x8x2_t vzipq_p16(poly16x8_t a, poly16x8_t b) { return vzipq_u16(a, b); }
 
 FORCE_INLINE int8x8x2_t vuzp_s8(int8x8_t a, int8x8_t b) {
   vint8m1_t ab = __riscv_vslideup_vx_i8m1(a, b, 8, 16);
@@ -13164,9 +13164,9 @@ FORCE_INLINE uint32x2x2_t vuzp_u32(uint32x2_t a, uint32x2_t b) {
   return __riscv_vcreate_v_u32m1x2(uzp1, uzp2);
 }
 
-// FORCE_INLINE poly8x8x2_t vuzp_p8(poly8x8_t a, poly8x8_t b);
+FORCE_INLINE poly8x8x2_t vuzp_p8(poly8x8_t a, poly8x8_t b) { return vuzp_u8(a, b); }
 
-// FORCE_INLINE poly16x4x2_t vuzp_p16(poly16x4_t a, poly16x4_t b);
+FORCE_INLINE poly16x4x2_t vuzp_p16(poly16x4_t a, poly16x4_t b) { return vuzp_u16(a, b); }
 
 FORCE_INLINE int8x16x2_t vuzpq_s8(int8x16_t a, int8x16_t b) {
   vint16m2_t ab =
@@ -13231,9 +13231,9 @@ FORCE_INLINE uint32x4x2_t vuzpq_u32(uint32x4_t a, uint32x4_t b) {
   return __riscv_vcreate_v_u32m1x2(uzp1, uzp2);
 }
 
-// FORCE_INLINE poly8x16x2_t vuzpq_p8(poly8x16_t a, poly8x16_t b);
+FORCE_INLINE poly8x16x2_t vuzpq_p8(poly8x16_t a, poly8x16_t b) { return vuzpq_u8(a, b); }
 
-// FORCE_INLINE poly16x8x2_t vuzpq_p16(poly16x8_t a, poly16x8_t b);
+FORCE_INLINE poly16x8x2_t vuzpq_p16(poly16x8_t a, poly16x8_t b) { return vuzpq_u16(a, b); }
 
 FORCE_INLINE int8x8_t vld1_s8(const int8_t *ptr) { return __riscv_vle8_v_i8m1(ptr, 8); }
 
@@ -13263,13 +13263,13 @@ FORCE_INLINE int64x2_t vld1q_s64(const int64_t *ptr) { return __riscv_vle64_v_i6
 
 FORCE_INLINE float32x4_t vld1q_f32(const float32_t *ptr) { return __riscv_vle32_v_f32m1(ptr, 4); }
 
-// FORCE_INLINE poly8x8_t vld1_p8(poly8_t const * ptr);
+FORCE_INLINE poly8x8_t vld1_p8(const poly8_t *ptr) { return vld1_u8(ptr); }
 
-// FORCE_INLINE poly8x16_t vld1q_p8(poly8_t const * ptr);
+FORCE_INLINE poly8x16_t vld1q_p8(const poly8_t *ptr) { return vld1q_u8(ptr); }
 
-// FORCE_INLINE poly16x4_t vld1_p16(poly16_t const * ptr);
+FORCE_INLINE poly16x4_t vld1_p16(const poly16_t *ptr) { return vld1_u16(ptr); }
 
-// FORCE_INLINE poly16x8_t vld1q_p16(poly16_t const * ptr);
+FORCE_INLINE poly16x8_t vld1q_p16(const poly16_t *ptr) { return vld1q_u16(ptr); }
 
 FORCE_INLINE float64x1_t vld1_f64(float64_t const *ptr) { return __riscv_vle64_v_f64m1(ptr, 1); }
 
@@ -13511,13 +13511,13 @@ FORCE_INLINE void vst1q_s64(int64_t *a, int64x2_t b) { __riscv_vse64_v_i64m1(a, 
 
 FORCE_INLINE void vst1q_f32(float32_t *a, float32x4_t b) { __riscv_vse32_v_f32m1(a, b, 4); }
 
-// FORCE_INLINE void vst1_p8(poly8_t * ptr, poly8x8_t val);
+FORCE_INLINE void vst1_p8(poly8_t *ptr, poly8x8_t val) { vst1_u8(ptr, val); }
 
-// FORCE_INLINE void vst1q_p8(poly8_t * ptr, poly8x16_t val);
+FORCE_INLINE void vst1q_p8(poly8_t *ptr, poly8x16_t val) { vst1q_u8(ptr, val); }
 
-// FORCE_INLINE void vst1_p16(poly16_t * ptr, poly16x4_t val);
+FORCE_INLINE void vst1_p16(poly16_t *ptr, poly16x4_t val) { vst1_u16(ptr, val); }
 
-// FORCE_INLINE void vst1q_p16(poly16_t * ptr, poly16x8_t val);
+FORCE_INLINE void vst1q_p16(poly16_t *ptr, poly16x8_t val) { vst1q_u16(ptr, val); }
 
 // FORCE_INLINE void vst1_f64(float64_t * ptr, float64x1_t val);
 
@@ -13604,13 +13604,13 @@ FORCE_INLINE void vst1q_lane_f32(float32_t *a, float32x4_t b, const int lane) {
   *a = __riscv_vfmv_f_s_f32m1_f32(b_s);
 }
 
-// FORCE_INLINE void vst1_lane_p8(poly8_t * ptr, poly8x8_t val, const int lane);
+FORCE_INLINE void vst1_lane_p8(poly8_t *ptr, poly8x8_t val, const int lane) { vst1_lane_u8(ptr, val, lane); }
 
-// FORCE_INLINE void vst1q_lane_p8(poly8_t * ptr, poly8x16_t val, const int lane);
+FORCE_INLINE void vst1q_lane_p8(poly8_t *ptr, poly8x16_t val, const int lane) { vst1q_lane_u8(ptr, val, lane); }
 
-// FORCE_INLINE void vst1_lane_p16(poly16_t * ptr, poly16x4_t val, const int lane);
+FORCE_INLINE void vst1_lane_p16(poly16_t *ptr, poly16x4_t val, const int lane) { vst1_lane_u16(ptr, val, lane); }
 
-// FORCE_INLINE void vst1q_lane_p16(poly16_t * ptr, poly16x8_t val, const int lane);
+FORCE_INLINE void vst1q_lane_p16(poly16_t *ptr, poly16x8_t val, const int lane) { vst1q_lane_u16(ptr, val, lane); }
 
 FORCE_INLINE void vst1_lane_f64(float64_t *a, float64x1_t b, const int lane) {
   vfloat64m1_t b_s = __riscv_vslidedown_vx_f64m1(b, lane, 1);
@@ -13693,13 +13693,13 @@ FORCE_INLINE int32x4x2_t vld2q_s32(const int32_t *a) { return __riscv_vlseg2e32_
 
 FORCE_INLINE float32x4x2_t vld2q_f32(const float32_t *a) { return __riscv_vlseg2e32_v_f32m1x2(a, 4); }
 
-// FORCE_INLINE poly8x8x2_t vld2_p8(poly8_t const * ptr);
+FORCE_INLINE poly8x8x2_t vld2_p8(const poly8_t *ptr) { return vld2_u8(ptr); }
 
-// FORCE_INLINE poly8x16x2_t vld2q_p8(poly8_t const * ptr);
+FORCE_INLINE poly8x16x2_t vld2q_p8(const poly8_t *ptr) { return vld2q_u8(ptr); }
 
-// FORCE_INLINE poly16x4x2_t vld2_p16(poly16_t const * ptr);
+FORCE_INLINE poly16x4x2_t vld2_p16(const poly16_t *ptr) { return vld2_u16(ptr); }
 
-// FORCE_INLINE poly16x8x2_t vld2q_p16(poly16_t const * ptr);
+FORCE_INLINE poly16x8x2_t vld2q_p16(const poly16_t *ptr) { return vld2q_u16(ptr); }
 
 FORCE_INLINE uint8x16x2_t vld2q_u8(const uint8_t *a) { return __riscv_vlseg2e8_v_u8m1x2(a, 16); }
 
@@ -13746,7 +13746,7 @@ FORCE_INLINE uint8x8x2_t vld2_lane_u8(const uint8_t *a, uint8x8x2_t b, const int
   return __riscv_vcreate_v_u8m1x2(c0, c1);
 }
 
-// FORCE_INLINE poly8x8x2_t vld2_lane_p8(poly8_t const * ptr, poly8x8x2_t src, const int lane);
+FORCE_INLINE poly8x8x2_t vld2_lane_p8(const poly8_t *ptr, poly8x8x2_t src, const int lane) { return vld2_lane_u8(ptr, src, lane); }
 
 // FORCE_INLINE int8x16x2_t vld2q_lane_s8(int8_t const * ptr, int8x16x2_t src, const int lane);
 
@@ -13805,9 +13805,9 @@ FORCE_INLINE float32x4x2_t vld2q_lane_f32(const float32_t *a, float32x4x2_t b, c
   return __riscv_vcreate_v_f32m1x2(c0, c1);
 }
 
-// FORCE_INLINE poly16x4x2_t vld2_lane_p16(poly16_t const * ptr, poly16x4x2_t src, const int lane);
+FORCE_INLINE poly16x4x2_t vld2_lane_p16(const poly16_t *ptr, poly16x4x2_t src, const int lane) { return vld2_lane_u16(ptr, src, lane); }
 
-// FORCE_INLINE poly16x8x2_t vld2q_lane_p16(poly16_t const * ptr, poly16x8x2_t src, const int lane);
+FORCE_INLINE poly16x8x2_t vld2q_lane_p16(const poly16_t *ptr, poly16x8x2_t src, const int lane) { return vld2q_lane_u16(ptr, src, lane); }
 
 FORCE_INLINE uint16x8x2_t vld2q_lane_u16(const uint16_t *a, uint16x8x2_t b, const int c) {
   vbool16_t mask = __riscv_vreinterpret_v_u16m1_b16(vdup_n_u16((uint8_t)(1 << c)));
@@ -13939,13 +13939,13 @@ FORCE_INLINE void vst2q_s32(int32_t *a, int32x4x2_t b) { return __riscv_vsseg2e3
 
 FORCE_INLINE void vst2q_f32(float32_t *a, float32x4x2_t b) { return __riscv_vsseg2e32_v_f32m1x2(a, b, 4); }
 
-// FORCE_INLINE void vst2_p8(poly8_t * ptr, poly8x8x2_t val);
+FORCE_INLINE void vst2_p8(poly8_t *ptr, poly8x8x2_t val) { vst2_u8(ptr, val); }
 
-// FORCE_INLINE void vst2q_p8(poly8_t * ptr, poly8x16x2_t val);
+FORCE_INLINE void vst2q_p8(poly8_t *ptr, poly8x16x2_t val) { vst2q_u8(ptr, val); }
 
-// FORCE_INLINE void vst2_p16(poly16_t * ptr, poly16x4x2_t val);
+FORCE_INLINE void vst2_p16(poly16_t *ptr, poly16x4x2_t val) { vst2_u16(ptr, val); }
 
-// FORCE_INLINE void vst2q_p16(poly16_t * ptr, poly16x8x2_t val);
+FORCE_INLINE void vst2q_p16(poly16_t *ptr, poly16x8x2_t val) { vst2q_u16(ptr, val); }
 
 FORCE_INLINE void vst2q_u8(uint8_t *a, uint8x16x2_t b) { return __riscv_vsseg2e8_v_u8m1x2(a, b, 16); }
 
@@ -14002,7 +14002,7 @@ FORCE_INLINE void vst2_lane_u8(uint8_t *a, uint8x8x2_t b, const int c) {
   a[1] = _b1[c];
 }
 
-// FORCE_INLINE void vst2_lane_p8(poly8_t * ptr, poly8x8x2_t val, const int lane);
+FORCE_INLINE void vst2_lane_p8(poly8_t *ptr, poly8x8x2_t val, const int lane) { vst2_lane_u8(ptr, val, lane); }
 
 FORCE_INLINE void vst2_lane_u16(uint16_t *a, uint16x4x2_t b, const int c) {
   vuint16m1_t b0 = __riscv_vget_v_u16m1x2_u16m1(b, 0);
@@ -14049,9 +14049,9 @@ FORCE_INLINE void vst2q_lane_f32(float32_t *a, float32x4x2_t b, const int c) {
   a[1] = _b1[c];
 }
 
-// FORCE_INLINE void vst2_lane_p16(poly16_t * ptr, poly16x4x2_t val, const int lane);
+FORCE_INLINE void vst2_lane_p16(poly16_t *ptr, poly16x4x2_t val, const int lane) { vst2_lane_u16(ptr, val, lane); }
 
-// FORCE_INLINE void vst2q_lane_p16(poly16_t * ptr, poly16x8x2_t val, const int lane);
+FORCE_INLINE void vst2q_lane_p16(poly16_t *ptr, poly16x8x2_t val, const int lane) { vst2q_lane_u16(ptr, val, lane); }
 
 // FORCE_INLINE void vst2q_lane_s8(int8_t * ptr, int8x16x2_t val, const int lane);
 
@@ -14135,13 +14135,13 @@ FORCE_INLINE int32x4x3_t vld3q_s32(const int32_t *a) { return __riscv_vlseg3e32_
 
 FORCE_INLINE float32x4x3_t vld3q_f32(const float32_t *a) { return __riscv_vlseg3e32_v_f32m1x3(a, 4); }
 
-// FORCE_INLINE poly8x8x3_t vld3_p8(poly8_t const * ptr);
+FORCE_INLINE poly8x8x3_t vld3_p8(const poly8_t *ptr) { return vld3_u8(ptr); }
 
-// FORCE_INLINE poly8x16x3_t vld3q_p8(poly8_t const * ptr);
+FORCE_INLINE poly8x16x3_t vld3q_p8(const poly8_t *ptr) { return vld3q_u8(ptr); }
 
-// FORCE_INLINE poly16x4x3_t vld3_p16(poly16_t const * ptr);
+FORCE_INLINE poly16x4x3_t vld3_p16(const poly16_t *ptr) { return vld3_u16(ptr); }
 
-// FORCE_INLINE poly16x8x3_t vld3q_p16(poly16_t const * ptr);
+FORCE_INLINE poly16x8x3_t vld3q_p16(const poly16_t *ptr) { return vld3q_u16(ptr); }
 
 FORCE_INLINE uint8x16x3_t vld3q_u8(const uint8_t *a) { return __riscv_vlseg3e8_v_u8m1x3(a, 16); }
 
@@ -14193,7 +14193,7 @@ FORCE_INLINE uint8x8x3_t vld3_lane_u8(const uint8_t *a, uint8x8x3_t b, const int
   return __riscv_vcreate_v_u8m1x3(c0, c1, c2);
 }
 
-// FORCE_INLINE poly8x8x3_t vld3_lane_p8(poly8_t const * ptr, poly8x8x3_t src, const int lane);
+FORCE_INLINE poly8x8x3_t vld3_lane_p8(const poly8_t *ptr, poly8x8x3_t src, const int lane) { return vld3_lane_u8(ptr, src, lane); }
 
 // FORCE_INLINE int8x16x3_t vld3q_lane_s8(int8_t const * ptr, int8x16x3_t src, const int lane);
 
@@ -14257,9 +14257,9 @@ FORCE_INLINE float32x4x3_t vld3q_lane_f32(const float32_t *a, float32x4x3_t b, c
   return __riscv_vcreate_v_f32m1x3(c0, c1, c2);
 }
 
-// FORCE_INLINE poly16x4x3_t vld3_lane_p16(poly16_t const * ptr, poly16x4x3_t src, const int lane);
+FORCE_INLINE poly16x4x3_t vld3_lane_p16(const poly16_t *ptr, poly16x4x3_t src, const int lane) { return vld3_lane_u16(ptr, src, lane); }
 
-// FORCE_INLINE poly16x8x3_t vld3q_lane_p16(poly16_t const * ptr, poly16x8x3_t src, const int lane);
+FORCE_INLINE poly16x8x3_t vld3q_lane_p16(const poly16_t *ptr, poly16x8x3_t src, const int lane) { return vld3q_lane_u16(ptr, src, lane); }
 
 FORCE_INLINE uint16x8x3_t vld3q_lane_u16(const uint16_t *a, uint16x8x3_t b, const int c) {
   vbool16_t mask = __riscv_vreinterpret_v_u8m1_b16(vdup_n_u8((uint8_t)(1 << c)));
@@ -14471,7 +14471,7 @@ FORCE_INLINE void vst3_lane_u8(uint8_t *a, uint8x8x3_t b, const int c) {
   a[2] = _b2[c];
 }
 
-// FORCE_INLINE void vst3_lane_p8(poly8_t * ptr, poly8x8x3_t val, const int lane);
+FORCE_INLINE void vst3_lane_p8(poly8_t *ptr, poly8x8x3_t val, const int lane) { vst3_lane_u8(ptr, val, lane); }
 
 FORCE_INLINE void vst3_lane_u16(uint16_t *a, uint16x4x3_t b, const int c) {
   vuint16m1_t b0 = __riscv_vget_v_u16m1x3_u16m1(b, 0);
@@ -14533,9 +14533,9 @@ FORCE_INLINE void vst3q_lane_f32(float32_t *a, float32x4x3_t b, const int c) {
   a[2] = _b2[c];
 }
 
-// FORCE_INLINE void vst3_lane_p16(poly16_t * ptr, poly16x4x3_t val, const int lane);
+FORCE_INLINE void vst3_lane_p16(poly16_t *ptr, poly16x4x3_t val, const int lane) { vst3_lane_u16(ptr, val, lane); }
 
-// FORCE_INLINE void vst3q_lane_p16(poly16_t * ptr, poly16x8x3_t val, const int lane);
+FORCE_INLINE void vst3q_lane_p16(poly16_t *ptr, poly16x8x3_t val, const int lane) { vst3q_lane_u16(ptr, val, lane); }
 
 // FORCE_INLINE void vst3q_lane_s8(int8_t * ptr, int8x16x3_t val, const int lane);
 
@@ -14625,13 +14625,13 @@ FORCE_INLINE int32x4x4_t vld4q_s32(const int32_t *a) { return __riscv_vlseg4e32_
 
 FORCE_INLINE float32x4x4_t vld4q_f32(const float32_t *a) { return __riscv_vlseg4e32_v_f32m1x4(a, 4); }
 
-// FORCE_INLINE poly8x8x4_t vld4_p8(poly8_t const * ptr);
+FORCE_INLINE poly8x8x4_t vld4_p8(const poly8_t *ptr) { return vld4_u8(ptr); }
 
-// FORCE_INLINE poly8x16x4_t vld4q_p8(poly8_t const * ptr);
+FORCE_INLINE poly8x16x4_t vld4q_p8(const poly8_t *ptr) { return vld4q_u8(ptr); }
 
-// FORCE_INLINE poly16x4x4_t vld4_p16(poly16_t const * ptr);
+FORCE_INLINE poly16x4x4_t vld4_p16(const poly16_t *ptr) { return vld4_u16(ptr); }
 
-// FORCE_INLINE poly16x8x4_t vld4q_p16(poly16_t const * ptr);
+FORCE_INLINE poly16x8x4_t vld4q_p16(const poly16_t *ptr) { return vld4q_u16(ptr); }
 
 FORCE_INLINE uint8x16x4_t vld4q_u8(const uint8_t *a) { return __riscv_vlseg4e8_v_u8m1x4(a, 16); }
 
@@ -14688,7 +14688,7 @@ FORCE_INLINE uint8x8x4_t vld4_lane_u8(const uint8_t *a, uint8x8x4_t b, const int
   return __riscv_vcreate_v_u8m1x4(c0, c1, c2, c3);
 }
 
-// FORCE_INLINE poly8x8x4_t vld4_lane_p8(poly8_t const * ptr, poly8x8x4_t src, const int lane);
+FORCE_INLINE poly8x8x4_t vld4_lane_p8(const poly8_t *ptr, poly8x8x4_t src, const int lane) { return vld4_lane_u8(ptr, src, lane); }
 
 // FORCE_INLINE int8x16x4_t vld4q_lane_s8(int8_t const * ptr, int8x16x4_t src, const int lane);
 
@@ -14757,9 +14757,9 @@ FORCE_INLINE float32x4x4_t vld4q_lane_f32(const float32_t *a, float32x4x4_t b, c
   return __riscv_vcreate_v_f32m1x4(c0, c1, c2, c3);
 }
 
-// FORCE_INLINE poly16x4x4_t vld4_lane_p16(poly16_t const * ptr, poly16x4x4_t src, const int lane);
+FORCE_INLINE poly16x4x4_t vld4_lane_p16(const poly16_t *ptr, poly16x4x4_t src, const int lane) { return vld4_lane_u16(ptr, src, lane); }
 
-// FORCE_INLINE poly16x8x4_t vld4q_lane_p16(poly16_t const * ptr, poly16x8x4_t src, const int lane);
+FORCE_INLINE poly16x8x4_t vld4q_lane_p16(const poly16_t *ptr, poly16x8x4_t src, const int lane) { return vld4q_lane_u16(ptr, src, lane); }
 
 FORCE_INLINE uint16x8x4_t vld4q_lane_u16(const uint16_t *a, uint16x8x4_t b, const int c) {
   vbool16_t mask = __riscv_vreinterpret_v_u8m1_b16(vdup_n_u8((uint8_t)(1 << c)));
@@ -14988,7 +14988,7 @@ FORCE_INLINE void vst4_lane_u8(uint8_t *a, uint8x8x4_t b, const int c) {
   a[3] = _b3[c];
 }
 
-// FORCE_INLINE void vst4_lane_p8(poly8_t * ptr, poly8x8x4_t val, const int lane);
+FORCE_INLINE void vst4_lane_p8(poly8_t *ptr, poly8x8x4_t val, const int lane) { vst4_lane_u8(ptr, val, lane); }
 
 FORCE_INLINE void vst4_lane_u16(uint16_t *a, uint16x4x4_t b, const int c) {
   vuint16m1_t b0 = __riscv_vget_v_u16m1x4_u16m1(b, 0);
@@ -15065,9 +15065,9 @@ FORCE_INLINE void vst4q_lane_f32(float32_t *a, float32x4x4_t b, const int c) {
   a[3] = _b3[c];
 }
 
-// FORCE_INLINE void vst4_lane_p16(poly16_t * ptr, poly16x4x4_t val, const int lane);
+FORCE_INLINE void vst4_lane_p16(poly16_t *ptr, poly16x4x4_t val, const int lane) { vst4_lane_u16(ptr, val, lane); }
 
-// FORCE_INLINE void vst4q_lane_p16(poly16_t * ptr, poly16x8x4_t val, const int lane);
+FORCE_INLINE void vst4q_lane_p16(poly16_t *ptr, poly16x8x4_t val, const int lane) { vst4q_lane_u16(ptr, val, lane); }
 
 // FORCE_INLINE void vst4q_lane_s8(int8_t * ptr, int8x16x4_t val, const int lane);
 

--- a/neon2rvv.h
+++ b/neon2rvv.h
@@ -65,6 +65,10 @@ extern "C" {
 typedef float float32_t;
 typedef double float64_t;
 
+// Polynomial scalar types — no dedicated RVV type; alias the matching uint.
+typedef uint8_t poly8_t;
+typedef uint16_t poly16_t;
+
 #if __riscv_v_min_vlen == 128 || __riscv_v_min_vlen == 256 || __riscv_v_min_vlen == 512
 // 64bit width vector register
 typedef vint8m1_t int8x8_t;
@@ -88,6 +92,12 @@ typedef vuint32m1_t uint32x4_t;
 typedef vuint64m1_t uint64x2_t;
 typedef vfloat32m1_t float32x4_t;
 typedef vfloat64m1_t float64x2_t;
+
+// Polynomial vector types — aliased to the corresponding uint vector types.
+typedef vuint8m1_t poly8x8_t;
+typedef vuint8m1_t poly8x16_t;
+typedef vuint16m1_t poly16x4_t;
+typedef vuint16m1_t poly16x8_t;
 
 typedef vint8m1x2_t int8x8x2_t;
 typedef vuint8m1x2_t uint8x8x2_t;
@@ -113,6 +123,19 @@ typedef vint16m1x3_t int16x8x3_t;
 typedef vuint16m1x3_t uint16x8x3_t;
 typedef vint16m1x4_t int16x8x4_t;
 typedef vuint16m1x4_t uint16x8x4_t;
+// Polynomial struct array types (for vld2/vld3/vld4 poly variants).
+typedef vuint8m1x2_t poly8x8x2_t;
+typedef vuint8m1x3_t poly8x8x3_t;
+typedef vuint8m1x4_t poly8x8x4_t;
+typedef vuint8m1x2_t poly8x16x2_t;
+typedef vuint8m1x3_t poly8x16x3_t;
+typedef vuint8m1x4_t poly8x16x4_t;
+typedef vuint16m1x2_t poly16x4x2_t;
+typedef vuint16m1x3_t poly16x4x3_t;
+typedef vuint16m1x4_t poly16x4x4_t;
+typedef vuint16m1x2_t poly16x8x2_t;
+typedef vuint16m1x3_t poly16x8x3_t;
+typedef vuint16m1x4_t poly16x8x4_t;
 typedef vint32m1x2_t int32x2x2_t;
 typedef vuint32m1x2_t uint32x2x2_t;
 typedef vint32m1x3_t int32x2x3_t;

--- a/neon2rvv.h
+++ b/neon2rvv.h
@@ -259,6 +259,14 @@ FORCE_INLINE uint64x2_t vdupq_n_u64(uint64_t a);
 
 FORCE_INLINE int8x8_t vcnt_s8(int8x8_t a);
 FORCE_INLINE uint8x8_t vcnt_u8(uint8x8_t a);
+FORCE_INLINE int8x16_t vcntq_s8(int8x16_t a);
+FORCE_INLINE uint8x16_t vcntq_u8(uint8x16_t a);
+FORCE_INLINE int8x8_t vclz_s8(int8x8_t a);
+FORCE_INLINE int16x4_t vclz_s16(int16x4_t a);
+FORCE_INLINE int32x2_t vclz_s32(int32x2_t a);
+FORCE_INLINE int8x16_t vclzq_s8(int8x16_t a);
+FORCE_INLINE int16x8_t vclzq_s16(int16x8_t a);
+FORCE_INLINE int32x4_t vclzq_s32(int32x4_t a);
 
 /* vadd */
 FORCE_INLINE int8x8_t vadd_s8(int8x8_t a, int8x8_t b) { return __riscv_vadd_vv_i8m1(a, b, 8); }
@@ -800,9 +808,35 @@ FORCE_INLINE int32x4_t vmulq_s32(int32x4_t a, int32x4_t b) { return __riscv_vmul
 
 FORCE_INLINE float32x4_t vmulq_f32(float32x4_t a, float32x4_t b) { return __riscv_vfmul_vv_f32m1(a, b, 4); }
 
-// FORCE_INLINE poly8x8_t vmul_p8(poly8x8_t a, poly8x8_t b);
+FORCE_INLINE poly8x8_t vmul_p8(poly8x8_t a, poly8x8_t b) {
+  uint8_t ae[8], be[8], re[8];
+  __riscv_vse8_v_u8m1(ae, a, 8);
+  __riscv_vse8_v_u8m1(be, b, 8);
+  for (int i = 0; i < 8; i++) {
+    uint16_t r = 0;
+    for (int j = 0; j < 8; j++) {
+      if (be[i] & (1u << j))
+        r ^= (uint16_t)ae[i] << j;
+    }
+    re[i] = (uint8_t)r;
+  }
+  return __riscv_vle8_v_u8m1(re, 8);
+}
 
-// FORCE_INLINE poly8x16_t vmulq_p8(poly8x16_t a, poly8x16_t b);
+FORCE_INLINE poly8x16_t vmulq_p8(poly8x16_t a, poly8x16_t b) {
+  uint8_t ae[16], be[16], re[16];
+  __riscv_vse8_v_u8m1(ae, a, 16);
+  __riscv_vse8_v_u8m1(be, b, 16);
+  for (int i = 0; i < 16; i++) {
+    uint16_t r = 0;
+    for (int j = 0; j < 8; j++) {
+      if (be[i] & (1u << j))
+        r ^= (uint16_t)ae[i] << j;
+    }
+    re[i] = (uint8_t)r;
+  }
+  return __riscv_vle8_v_u8m1(re, 16);
+}
 
 FORCE_INLINE float64x1_t vmul_f64(float64x1_t a, float64x1_t b) { return __riscv_vfmul_vv_f64m1(a, b, 1); }
 
@@ -1092,7 +1126,21 @@ FORCE_INLINE uint64x2_t vmull_u32(uint32x2_t a, uint32x2_t b) {
   return __riscv_vlmul_trunc_v_u64m2_u64m1(__riscv_vwmulu_vv_u64m2(a, b, 2));
 }
 
-// FORCE_INLINE poly16x8_t vmull_p8(poly8x8_t a, poly8x8_t b);
+FORCE_INLINE poly16x8_t vmull_p8(poly8x8_t a, poly8x8_t b) {
+  uint8_t ae[8], be[8];
+  uint16_t re[8];
+  __riscv_vse8_v_u8m1(ae, a, 8);
+  __riscv_vse8_v_u8m1(be, b, 8);
+  for (int i = 0; i < 8; i++) {
+    uint16_t r = 0;
+    for (int j = 0; j < 8; j++) {
+      if (be[i] & (1u << j))
+        r ^= (uint16_t)ae[i] << j;
+    }
+    re[i] = r;
+  }
+  return __riscv_vle16_v_u16m1(re, 8);
+}
 
 FORCE_INLINE int16x8_t vmull_high_s8(int8x16_t a, int8x16_t b) {
   vint8mf2_t a_high = __riscv_vlmul_trunc_v_i8m1_i8mf2(__riscv_vslidedown_vx_i8m1(a, 8, 16));
@@ -2172,9 +2220,12 @@ FORCE_INLINE uint32x4_t vceqq_f32(float32x4_t a, float32x4_t b) {
   return __riscv_vmerge_vvm_u32m1(vdupq_n_u32(0x0), vdupq_n_u32(UINT32_MAX), cmp_res, 4);
 }
 
-// FORCE_INLINE uint8x8_t vceq_p8(poly8x8_t a, poly8x8_t b);
+FORCE_INLINE uint8x8_t vceq_p8(poly8x8_t a, poly8x8_t b) { return vceq_u8(a, b); }
 
-// FORCE_INLINE uint8x16_t vceqq_p8(poly8x16_t a, poly8x16_t b);
+FORCE_INLINE uint8x16_t vceqq_p8(poly8x16_t a, poly8x16_t b) {
+  vbool8_t cmp_res = __riscv_vmseq_vv_u8m1_b8(a, b, 16);
+  return __riscv_vmerge_vvm_u8m1(__riscv_vmv_v_x_u8m1(0, 16), __riscv_vmv_v_x_u8m1(UINT8_MAX, 16), cmp_res, 16);
+}
 
 FORCE_INLINE uint64x1_t vceq_s64(int64x1_t a, int64x1_t b) {
   vbool64_t cmp_res = __riscv_vmseq_vv_i64m1_b64(a, b, 1);
@@ -5664,7 +5715,32 @@ FORCE_INLINE int32x2_t vqrshl_s32(int32x2_t a, int32x2_t b) {
   return __riscv_vmerge_vvm_i32m1(shr, shl, positive_mask, 2);
 }
 
-// FORCE_INLINE int64x1_t vqrshl_s64(int64x1_t a, int64x1_t b);
+FORCE_INLINE int64x1_t vqrshl_s64(int64x1_t a, int64x1_t b) {
+  int64_t av = __riscv_vmv_x_s_i64m1_i64(a);
+  int64_t bv = __riscv_vmv_x_s_i64m1_i64(b);
+  int64_t res;
+  if (bv < 0) {
+    int64_t sh = -bv;
+    if (sh >= 64) {
+      res = av >= 0 ? 0 : -1;
+    } else {
+      int64_t rb = (sh > 0) ? ((av >> (sh - 1)) & 1) : 0;
+      res = (av >> sh) + rb;
+    }
+  } else if (bv == 0) {
+    res = av;
+  } else if (bv >= 64) {
+    res = av > 0 ? INT64_MAX : (av < 0 ? INT64_MIN : 0);
+  } else {
+    if (av > 0 && av > (INT64_MAX >> bv))
+      res = INT64_MAX;
+    else if (av < 0 && av < (INT64_MIN >> bv))
+      res = INT64_MIN;
+    else
+      res = av << bv;
+  }
+  return __riscv_vmv_s_x_i64m1(res, 1);
+}
 
 FORCE_INLINE uint8x8_t vqrshl_u8(uint8x8_t a, int8x8_t b) {
   vbool8_t positive_mask = __riscv_vmsgt_vx_i8m1_b8(b, 0, 8);
@@ -5705,7 +5781,30 @@ FORCE_INLINE uint32x2_t vqrshl_u32(uint32x2_t a, int32x2_t b) {
   return __riscv_vmerge_vvm_u32m1(shr, shl, positive_mask, 2);
 }
 
-// FORCE_INLINE uint64x1_t vqrshl_u64(uint64x1_t a, int64x1_t b);
+FORCE_INLINE uint64x1_t vqrshl_u64(uint64x1_t a, int64x1_t b) {
+  uint64_t av = __riscv_vmv_x_s_u64m1_u64(a);
+  int64_t bv = __riscv_vmv_x_s_i64m1_i64(b);
+  uint64_t res;
+  if (bv < 0) {
+    int64_t sh = -bv;
+    if (sh >= 64) {
+      res = 0;
+    } else {
+      uint64_t rb = (sh > 0) ? ((av >> (sh - 1)) & 1u) : 0u;
+      res = (av >> sh) + rb;
+    }
+  } else if (bv == 0) {
+    res = av;
+  } else if (bv >= 64) {
+    res = av != 0 ? UINT64_MAX : 0u;
+  } else {
+    if (av > (UINT64_MAX >> bv))
+      res = UINT64_MAX;
+    else
+      res = av << bv;
+  }
+  return __riscv_vmv_s_x_u64m1(res, 1);
+}
 
 FORCE_INLINE int8x16_t vqrshlq_s8(int8x16_t a, int8x16_t b) {
   vbool8_t positive_mask = __riscv_vmsgt_vx_i8m1_b8(b, 0, 16);
@@ -5746,7 +5845,30 @@ FORCE_INLINE int32x4_t vqrshlq_s32(int32x4_t a, int32x4_t b) {
   return __riscv_vmerge_vvm_i32m1(shr, shl, positive_mask, 4);
 }
 
-// FORCE_INLINE int64x2_t vqrshlq_s64(int64x2_t a, int64x2_t b);
+FORCE_INLINE int64x2_t vqrshlq_s64(int64x2_t a, int64x2_t b) {
+  int64_t ae[2], be[2], re[2];
+  __riscv_vse64_v_i64m1(ae, a, 2);
+  __riscv_vse64_v_i64m1(be, b, 2);
+  for (int i = 0; i < 2; i++) {
+    int64_t av = ae[i], bv = be[i];
+    if (bv < 0) {
+      int64_t sh = -bv;
+      re[i] = sh >= 64 ? (av >= 0 ? 0 : -1) : (av >> sh) + ((av >> (sh - 1)) & 1);
+    } else if (bv == 0) {
+      re[i] = av;
+    } else if (bv >= 64) {
+      re[i] = av > 0 ? INT64_MAX : (av < 0 ? INT64_MIN : 0);
+    } else {
+      if (av > 0 && av > (INT64_MAX >> bv))
+        re[i] = INT64_MAX;
+      else if (av < 0 && av < (INT64_MIN >> bv))
+        re[i] = INT64_MIN;
+      else
+        re[i] = av << bv;
+    }
+  }
+  return __riscv_vle64_v_i64m1(re, 2);
+}
 
 FORCE_INLINE uint8x16_t vqrshlq_u8(uint8x16_t a, int8x16_t b) {
   vbool8_t positive_mask = __riscv_vmsgt_vx_i8m1_b8(b, 0, 16);
@@ -5787,7 +5909,28 @@ FORCE_INLINE uint32x4_t vqrshlq_u32(uint32x4_t a, int32x4_t b) {
   return __riscv_vmerge_vvm_u32m1(shr, shl, positive_mask, 4);
 }
 
-// FORCE_INLINE uint64x2_t vqrshlq_u64(uint64x2_t a, int64x2_t b);
+FORCE_INLINE uint64x2_t vqrshlq_u64(uint64x2_t a, int64x2_t b) {
+  uint64_t ae[2];
+  int64_t be[2];
+  uint64_t re[2];
+  __riscv_vse64_v_u64m1(ae, a, 2);
+  __riscv_vse64_v_i64m1(be, b, 2);
+  for (int i = 0; i < 2; i++) {
+    uint64_t av = ae[i];
+    int64_t bv = be[i];
+    if (bv < 0) {
+      int64_t sh = -bv;
+      re[i] = sh >= 64 ? 0u : (av >> sh) + ((av >> (sh - 1)) & 1u);
+    } else if (bv == 0) {
+      re[i] = av;
+    } else if (bv >= 64) {
+      re[i] = av != 0 ? UINT64_MAX : 0u;
+    } else {
+      re[i] = av > (UINT64_MAX >> bv) ? UINT64_MAX : av << bv;
+    }
+  }
+  return __riscv_vle64_v_u64m1(re, 2);
+}
 
 // FORCE_INLINE int8_t vqrshlb_s8(int8_t a, int8_t b);
 
@@ -7392,33 +7535,75 @@ FORCE_INLINE uint16x8_t vmvnq_u16(uint16x8_t a) { return __riscv_vnot_v_u16m1(a,
 
 FORCE_INLINE uint32x4_t vmvnq_u32(uint32x4_t a) { return __riscv_vnot_v_u32m1(a, 4); }
 
-// FORCE_INLINE poly8x8_t vmvn_p8(poly8x8_t a);
+FORCE_INLINE poly8x8_t vmvn_p8(poly8x8_t a) { return __riscv_vnot_v_u8m1(a, 8); }
 
-// FORCE_INLINE poly8x16_t vmvnq_p8(poly8x16_t a);
+FORCE_INLINE poly8x16_t vmvnq_p8(poly8x16_t a) { return __riscv_vnot_v_u8m1(a, 16); }
 
-// FORCE_INLINE int8x8_t vcls_s8(int8x8_t a);
+FORCE_INLINE int8x8_t vcls_s8(int8x8_t a) {
+  vuint8m1_t a_u = __riscv_vreinterpret_v_i8m1_u8m1(a);
+  vuint8m1_t xored = __riscv_vxor_vv_u8m1(a_u, __riscv_vsrl_vx_u8m1(a_u, 1, 8), 8);
+  return __riscv_vsub_vx_i8m1(vclz_s8(__riscv_vreinterpret_v_u8m1_i8m1(xored)), 1, 8);
+}
 
-// FORCE_INLINE int16x4_t vcls_s16(int16x4_t a);
+FORCE_INLINE int16x4_t vcls_s16(int16x4_t a) {
+  vuint16m1_t a_u = __riscv_vreinterpret_v_i16m1_u16m1(a);
+  vuint16m1_t xored = __riscv_vxor_vv_u16m1(a_u, __riscv_vsrl_vx_u16m1(a_u, 1, 4), 4);
+  return __riscv_vsub_vx_i16m1(vclz_s16(__riscv_vreinterpret_v_u16m1_i16m1(xored)), 1, 4);
+}
 
-// FORCE_INLINE int32x2_t vcls_s32(int32x2_t a);
+FORCE_INLINE int32x2_t vcls_s32(int32x2_t a) {
+  vuint32m1_t a_u = __riscv_vreinterpret_v_i32m1_u32m1(a);
+  vuint32m1_t xored = __riscv_vxor_vv_u32m1(a_u, __riscv_vsrl_vx_u32m1(a_u, 1, 2), 2);
+  return __riscv_vsub_vx_i32m1(vclz_s32(__riscv_vreinterpret_v_u32m1_i32m1(xored)), 1, 2);
+}
 
-// FORCE_INLINE int8x16_t vclsq_s8(int8x16_t a);
+FORCE_INLINE int8x16_t vclsq_s8(int8x16_t a) {
+  vuint8m1_t a_u = __riscv_vreinterpret_v_i8m1_u8m1(a);
+  vuint8m1_t xored = __riscv_vxor_vv_u8m1(a_u, __riscv_vsrl_vx_u8m1(a_u, 1, 16), 16);
+  return __riscv_vsub_vx_i8m1(vclzq_s8(__riscv_vreinterpret_v_u8m1_i8m1(xored)), 1, 16);
+}
 
-// FORCE_INLINE int16x8_t vclsq_s16(int16x8_t a);
+FORCE_INLINE int16x8_t vclsq_s16(int16x8_t a) {
+  vuint16m1_t a_u = __riscv_vreinterpret_v_i16m1_u16m1(a);
+  vuint16m1_t xored = __riscv_vxor_vv_u16m1(a_u, __riscv_vsrl_vx_u16m1(a_u, 1, 8), 8);
+  return __riscv_vsub_vx_i16m1(vclzq_s16(__riscv_vreinterpret_v_u16m1_i16m1(xored)), 1, 8);
+}
 
-// FORCE_INLINE int32x4_t vclsq_s32(int32x4_t a);
+FORCE_INLINE int32x4_t vclsq_s32(int32x4_t a) {
+  vuint32m1_t a_u = __riscv_vreinterpret_v_i32m1_u32m1(a);
+  vuint32m1_t xored = __riscv_vxor_vv_u32m1(a_u, __riscv_vsrl_vx_u32m1(a_u, 1, 4), 4);
+  return __riscv_vsub_vx_i32m1(vclzq_s32(__riscv_vreinterpret_v_u32m1_i32m1(xored)), 1, 4);
+}
 
-// FORCE_INLINE int8x8_t vcls_u8(uint8x8_t a);
+FORCE_INLINE int8x8_t vcls_u8(uint8x8_t a) {
+  vuint8m1_t xored = __riscv_vxor_vv_u8m1(a, __riscv_vsrl_vx_u8m1(a, 1, 8), 8);
+  return __riscv_vsub_vx_i8m1(vclz_s8(__riscv_vreinterpret_v_u8m1_i8m1(xored)), 1, 8);
+}
 
-// FORCE_INLINE int8x16_t vclsq_u8(uint8x16_t a);
+FORCE_INLINE int8x16_t vclsq_u8(uint8x16_t a) {
+  vuint8m1_t xored = __riscv_vxor_vv_u8m1(a, __riscv_vsrl_vx_u8m1(a, 1, 16), 16);
+  return __riscv_vsub_vx_i8m1(vclzq_s8(__riscv_vreinterpret_v_u8m1_i8m1(xored)), 1, 16);
+}
 
-// FORCE_INLINE int16x4_t vcls_u16(uint16x4_t a);
+FORCE_INLINE int16x4_t vcls_u16(uint16x4_t a) {
+  vuint16m1_t xored = __riscv_vxor_vv_u16m1(a, __riscv_vsrl_vx_u16m1(a, 1, 4), 4);
+  return __riscv_vsub_vx_i16m1(vclz_s16(__riscv_vreinterpret_v_u16m1_i16m1(xored)), 1, 4);
+}
 
-// FORCE_INLINE int16x8_t vclsq_u16(uint16x8_t a);
+FORCE_INLINE int16x8_t vclsq_u16(uint16x8_t a) {
+  vuint16m1_t xored = __riscv_vxor_vv_u16m1(a, __riscv_vsrl_vx_u16m1(a, 1, 8), 8);
+  return __riscv_vsub_vx_i16m1(vclzq_s16(__riscv_vreinterpret_v_u16m1_i16m1(xored)), 1, 8);
+}
 
-// FORCE_INLINE int32x2_t vcls_u32(uint32x2_t a);
+FORCE_INLINE int32x2_t vcls_u32(uint32x2_t a) {
+  vuint32m1_t xored = __riscv_vxor_vv_u32m1(a, __riscv_vsrl_vx_u32m1(a, 1, 2), 2);
+  return __riscv_vsub_vx_i32m1(vclz_s32(__riscv_vreinterpret_v_u32m1_i32m1(xored)), 1, 2);
+}
 
-// FORCE_INLINE int32x4_t vclsq_u32(uint32x4_t a);
+FORCE_INLINE int32x4_t vclsq_u32(uint32x4_t a) {
+  vuint32m1_t xored = __riscv_vxor_vv_u32m1(a, __riscv_vsrl_vx_u32m1(a, 1, 4), 4);
+  return __riscv_vsub_vx_i32m1(vclzq_s32(__riscv_vreinterpret_v_u32m1_i32m1(xored)), 1, 4);
+}
 
 FORCE_INLINE int8x8_t vclz_s8(int8x8_t a) {
   // refer
@@ -7431,27 +7616,112 @@ FORCE_INLINE int8x8_t vclz_s8(int8x8_t a) {
   return vcnt_s8(__riscv_vreinterpret_v_u8m1_i8m1(a_not));
 }
 
-// FORCE_INLINE int16x4_t vclz_s16(int16x4_t a);
+FORCE_INLINE int16x4_t vclz_s16(int16x4_t a) {
+  vuint16m1_t a_u = __riscv_vreinterpret_v_i16m1_u16m1(a);
+  a_u = __riscv_vor_vv_u16m1(__riscv_vsrl_vx_u16m1(a_u, 1, 4), a_u, 4);
+  a_u = __riscv_vor_vv_u16m1(__riscv_vsrl_vx_u16m1(a_u, 2, 4), a_u, 4);
+  a_u = __riscv_vor_vv_u16m1(__riscv_vsrl_vx_u16m1(a_u, 4, 4), a_u, 4);
+  a_u = __riscv_vor_vv_u16m1(__riscv_vsrl_vx_u16m1(a_u, 8, 4), a_u, 4);
+  /* popcount each byte, then sum the two bytes per element */
+  vuint8m1_t bytes = __riscv_vreinterpret_v_u16m1_u8m1(__riscv_vnot_v_u16m1(a_u, 4));
+  vuint8m1_t cnt = vcnt_u8(bytes);
+  vuint16m1_t cnt16 = __riscv_vreinterpret_v_u8m1_u16m1(cnt);
+  vuint16m1_t lo = __riscv_vand_vx_u16m1(cnt16, 0xff, 4);
+  vuint16m1_t hi = __riscv_vsrl_vx_u16m1(cnt16, 8, 4);
+  return __riscv_vreinterpret_v_u16m1_i16m1(__riscv_vadd_vv_u16m1(lo, hi, 4));
+}
 
-// FORCE_INLINE int32x2_t vclz_s32(int32x2_t a);
+FORCE_INLINE int32x2_t vclz_s32(int32x2_t a) {
+  vuint32m1_t a_u = __riscv_vreinterpret_v_i32m1_u32m1(a);
+  a_u = __riscv_vor_vv_u32m1(__riscv_vsrl_vx_u32m1(a_u, 1, 2), a_u, 2);
+  a_u = __riscv_vor_vv_u32m1(__riscv_vsrl_vx_u32m1(a_u, 2, 2), a_u, 2);
+  a_u = __riscv_vor_vv_u32m1(__riscv_vsrl_vx_u32m1(a_u, 4, 2), a_u, 2);
+  a_u = __riscv_vor_vv_u32m1(__riscv_vsrl_vx_u32m1(a_u, 8, 2), a_u, 2);
+  a_u = __riscv_vor_vv_u32m1(__riscv_vsrl_vx_u32m1(a_u, 16, 2), a_u, 2);
+  vuint8m1_t bytes = __riscv_vreinterpret_v_u32m1_u8m1(__riscv_vnot_v_u32m1(a_u, 2));
+  vuint8m1_t cnt = vcnt_u8(bytes);
+  /* Sum 4 bytes per 32-bit element */
+  vuint16m1_t cnt16 = __riscv_vreinterpret_v_u8m1_u16m1(cnt);
+  vuint16m1_t sum16_lo = __riscv_vand_vx_u16m1(cnt16, 0xff, 4);
+  vuint16m1_t sum16_hi = __riscv_vsrl_vx_u16m1(cnt16, 8, 4);
+  vuint16m1_t sum16 = __riscv_vadd_vv_u16m1(sum16_lo, sum16_hi, 4);
+  vuint32m1_t sum32 = __riscv_vreinterpret_v_u16m1_u32m1(sum16);
+  vuint32m1_t lo = __riscv_vand_vx_u32m1(sum32, 0xffff, 2);
+  vuint32m1_t hi = __riscv_vsrl_vx_u32m1(sum32, 16, 2);
+  return __riscv_vreinterpret_v_u32m1_i32m1(__riscv_vadd_vv_u32m1(lo, hi, 2));
+}
 
-// FORCE_INLINE uint8x8_t vclz_u8(uint8x8_t a);
+FORCE_INLINE uint8x8_t vclz_u8(uint8x8_t a) {
+  a = __riscv_vor_vv_u8m1(__riscv_vsrl_vx_u8m1(a, 1, 8), a, 8);
+  a = __riscv_vor_vv_u8m1(__riscv_vsrl_vx_u8m1(a, 2, 8), a, 8);
+  a = __riscv_vor_vv_u8m1(__riscv_vsrl_vx_u8m1(a, 4, 8), a, 8);
+  return __riscv_vreinterpret_v_i8m1_u8m1(vcnt_s8(__riscv_vreinterpret_v_u8m1_i8m1(__riscv_vnot_v_u8m1(a, 8))));
+}
 
-// FORCE_INLINE uint16x4_t vclz_u16(uint16x4_t a);
+FORCE_INLINE uint16x4_t vclz_u16(uint16x4_t a) {
+  return __riscv_vreinterpret_v_i16m1_u16m1(vclz_s16(__riscv_vreinterpret_v_u16m1_i16m1(a)));
+}
 
-// FORCE_INLINE uint32x2_t vclz_u32(uint32x2_t a);
+FORCE_INLINE uint32x2_t vclz_u32(uint32x2_t a) {
+  return __riscv_vreinterpret_v_i32m1_u32m1(vclz_s32(__riscv_vreinterpret_v_u32m1_i32m1(a)));
+}
 
-// FORCE_INLINE int8x16_t vclzq_s8(int8x16_t a);
+FORCE_INLINE int8x16_t vclzq_s8(int8x16_t a) {
+  vuint8m1_t a_u = __riscv_vreinterpret_v_i8m1_u8m1(a);
+  a_u = __riscv_vor_vv_u8m1(__riscv_vsrl_vx_u8m1(a_u, 1, 16), a_u, 16);
+  a_u = __riscv_vor_vv_u8m1(__riscv_vsrl_vx_u8m1(a_u, 2, 16), a_u, 16);
+  a_u = __riscv_vor_vv_u8m1(__riscv_vsrl_vx_u8m1(a_u, 4, 16), a_u, 16);
+  vuint8m1_t a_not = __riscv_vnot_v_u8m1(a_u, 16);
+  return vcntq_s8(__riscv_vreinterpret_v_u8m1_i8m1(a_not));
+}
 
-// FORCE_INLINE int16x8_t vclzq_s16(int16x8_t a);
+FORCE_INLINE int16x8_t vclzq_s16(int16x8_t a) {
+  vuint16m1_t a_u = __riscv_vreinterpret_v_i16m1_u16m1(a);
+  a_u = __riscv_vor_vv_u16m1(__riscv_vsrl_vx_u16m1(a_u, 1, 8), a_u, 8);
+  a_u = __riscv_vor_vv_u16m1(__riscv_vsrl_vx_u16m1(a_u, 2, 8), a_u, 8);
+  a_u = __riscv_vor_vv_u16m1(__riscv_vsrl_vx_u16m1(a_u, 4, 8), a_u, 8);
+  a_u = __riscv_vor_vv_u16m1(__riscv_vsrl_vx_u16m1(a_u, 8, 8), a_u, 8);
+  vuint8m1_t bytes = __riscv_vreinterpret_v_u16m1_u8m1(__riscv_vnot_v_u16m1(a_u, 8));
+  vuint8m1_t cnt = vcntq_u8(bytes);
+  vuint16m1_t cnt16 = __riscv_vreinterpret_v_u8m1_u16m1(cnt);
+  vuint16m1_t lo = __riscv_vand_vx_u16m1(cnt16, 0xff, 8);
+  vuint16m1_t hi = __riscv_vsrl_vx_u16m1(cnt16, 8, 8);
+  return __riscv_vreinterpret_v_u16m1_i16m1(__riscv_vadd_vv_u16m1(lo, hi, 8));
+}
 
-// FORCE_INLINE int32x4_t vclzq_s32(int32x4_t a);
+FORCE_INLINE int32x4_t vclzq_s32(int32x4_t a) {
+  vuint32m1_t a_u = __riscv_vreinterpret_v_i32m1_u32m1(a);
+  a_u = __riscv_vor_vv_u32m1(__riscv_vsrl_vx_u32m1(a_u, 1, 4), a_u, 4);
+  a_u = __riscv_vor_vv_u32m1(__riscv_vsrl_vx_u32m1(a_u, 2, 4), a_u, 4);
+  a_u = __riscv_vor_vv_u32m1(__riscv_vsrl_vx_u32m1(a_u, 4, 4), a_u, 4);
+  a_u = __riscv_vor_vv_u32m1(__riscv_vsrl_vx_u32m1(a_u, 8, 4), a_u, 4);
+  a_u = __riscv_vor_vv_u32m1(__riscv_vsrl_vx_u32m1(a_u, 16, 4), a_u, 4);
+  vuint8m1_t bytes = __riscv_vreinterpret_v_u32m1_u8m1(__riscv_vnot_v_u32m1(a_u, 4));
+  vuint8m1_t cnt = vcntq_u8(bytes);
+  vuint16m1_t cnt16 = __riscv_vreinterpret_v_u8m1_u16m1(cnt);
+  vuint16m1_t sum16_lo = __riscv_vand_vx_u16m1(cnt16, 0xff, 8);
+  vuint16m1_t sum16_hi = __riscv_vsrl_vx_u16m1(cnt16, 8, 8);
+  vuint16m1_t sum16 = __riscv_vadd_vv_u16m1(sum16_lo, sum16_hi, 8);
+  vuint32m1_t sum32 = __riscv_vreinterpret_v_u16m1_u32m1(sum16);
+  vuint32m1_t lo = __riscv_vand_vx_u32m1(sum32, 0xffff, 4);
+  vuint32m1_t hi = __riscv_vsrl_vx_u32m1(sum32, 16, 4);
+  return __riscv_vreinterpret_v_u32m1_i32m1(__riscv_vadd_vv_u32m1(lo, hi, 4));
+}
 
-// FORCE_INLINE uint8x16_t vclzq_u8(uint8x16_t a);
+FORCE_INLINE uint8x16_t vclzq_u8(uint8x16_t a) {
+  a = __riscv_vor_vv_u8m1(__riscv_vsrl_vx_u8m1(a, 1, 16), a, 16);
+  a = __riscv_vor_vv_u8m1(__riscv_vsrl_vx_u8m1(a, 2, 16), a, 16);
+  a = __riscv_vor_vv_u8m1(__riscv_vsrl_vx_u8m1(a, 4, 16), a, 16);
+  return __riscv_vreinterpret_v_i8m1_u8m1(vcntq_s8(__riscv_vreinterpret_v_u8m1_i8m1(__riscv_vnot_v_u8m1(a, 16))));
+}
 
-// FORCE_INLINE uint16x8_t vclzq_u16(uint16x8_t a);
+FORCE_INLINE uint16x8_t vclzq_u16(uint16x8_t a) {
+  return __riscv_vreinterpret_v_i16m1_u16m1(vclzq_s16(__riscv_vreinterpret_v_u16m1_i16m1(a)));
+}
 
-// FORCE_INLINE uint32x4_t vclzq_u32(uint32x4_t a);
+FORCE_INLINE uint32x4_t vclzq_u32(uint32x4_t a) {
+  return __riscv_vreinterpret_v_i32m1_u32m1(vclzq_s32(__riscv_vreinterpret_v_u32m1_i32m1(a)));
+}
 
 FORCE_INLINE int8x8_t vcnt_s8(int8x8_t a) {
   const int8_t bit_population_lookup_arr[16] = {0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4};
@@ -7493,11 +7763,25 @@ FORCE_INLINE uint8x16_t vcntq_u8(uint8x16_t a) {
 
 // FORCE_INLINE poly8x8_t vcnt_p8(poly8x8_t a);
 
-// FORCE_INLINE poly8x16_t vcntq_p8(poly8x16_t a);
+FORCE_INLINE poly8x8_t vcnt_p8(poly8x8_t a) { return vcnt_u8(a); }
+
+FORCE_INLINE poly8x16_t vcntq_p8(poly8x16_t a) { return vcntq_u8(a); }
 
 FORCE_INLINE float32x2_t vrecpe_f32(float32x2_t a) { return __riscv_vfrec7_v_f32m1(a, 2); }
 
-// FORCE_INLINE uint32x2_t vrecpe_u32(uint32x2_t a);
+FORCE_INLINE uint32x2_t vrecpe_u32(uint32x2_t a) {
+  uint32_t e[2];
+  __riscv_vse32_v_u32m1(e, a, 2);
+  for (int i = 0; i < 2; i++) {
+    uint32_t x9 = e[i] >> 23;
+    if (!(x9 >> 8)) {
+      e[i] = 0xFFFFFFFFu;
+    } else {
+      e[i] = (uint32_t)(131072.0 / (x9 + 0.5) + (x9 & 1u) * 0.5) << 23;
+    }
+  }
+  return __riscv_vle32_v_u32m1(e, 2);
+}
 
 FORCE_INLINE float32x4_t vrecpeq_f32(float32x4_t a) { return __riscv_vfrec7_v_f32m1(a, 4); }
 
@@ -7509,11 +7793,35 @@ FORCE_INLINE float32_t vrecpes_f32(float32_t a) { return 1.0f / a; }
 
 FORCE_INLINE float64_t vrecped_f64(float64_t a) { return 1.0f / a; }
 
-// FORCE_INLINE uint32x4_t vrecpeq_u32(uint32x4_t a);
+FORCE_INLINE uint32x4_t vrecpeq_u32(uint32x4_t a) {
+  uint32_t e[4];
+  __riscv_vse32_v_u32m1(e, a, 4);
+  for (int i = 0; i < 4; i++) {
+    uint32_t x9 = e[i] >> 23;
+    if (!(x9 >> 8)) {
+      e[i] = 0xFFFFFFFFu;
+    } else {
+      e[i] = (uint32_t)(131072.0 / (x9 + 0.5) + (x9 & 1u) * 0.5) << 23;
+    }
+  }
+  return __riscv_vle32_v_u32m1(e, 4);
+}
 
 FORCE_INLINE float32x2_t vrsqrte_f32(float32x2_t a) { return __riscv_vfrsqrt7_v_f32m1(a, 2); }
 
-// FORCE_INLINE uint32x2_t vrsqrte_u32(uint32x2_t a);
+FORCE_INLINE uint32x2_t vrsqrte_u32(uint32x2_t a) {
+  uint32_t e[2];
+  __riscv_vse32_v_u32m1(e, a, 2);
+  for (int i = 0; i < 2; i++) {
+    uint32_t x9 = e[i] >> 23;
+    if (x9 < 128u) {
+      e[i] = 0xFFFFFFFFu;
+    } else {
+      e[i] = (uint32_t)(256.0 * sqrt(512.0 / (x9 + 0.5)) + (x9 & 1u) * 0.5) << 23;
+    }
+  }
+  return __riscv_vle32_v_u32m1(e, 2);
+}
 
 FORCE_INLINE float32x4_t vrsqrteq_f32(float32x4_t a) { return __riscv_vfrsqrt7_v_f32m1(a, 4); }
 
@@ -7525,7 +7833,19 @@ FORCE_INLINE float32_t vrsqrtes_f32(float32_t a) { return 1 / sqrtf(a); }
 
 FORCE_INLINE float64_t vrsqrted_f64(float64_t a) { return 1 / sqrt(a); }
 
-// FORCE_INLINE uint32x4_t vrsqrteq_u32(uint32x4_t a);
+FORCE_INLINE uint32x4_t vrsqrteq_u32(uint32x4_t a) {
+  uint32_t e[4];
+  __riscv_vse32_v_u32m1(e, a, 4);
+  for (int i = 0; i < 4; i++) {
+    uint32_t x9 = e[i] >> 23;
+    if (x9 < 128u) {
+      e[i] = 0xFFFFFFFFu;
+    } else {
+      e[i] = (uint32_t)(256.0 * sqrt(512.0 / (x9 + 0.5)) + (x9 & 1u) * 0.5) << 23;
+    }
+  }
+  return __riscv_vle32_v_u32m1(e, 4);
+}
 
 FORCE_INLINE int8_t vget_lane_s8(int8x8_t a, const int b) {
   return __riscv_vmv_x_s_i8m1_i8(__riscv_vslidedown_vx_i8m1(a, b, 8));
@@ -7561,9 +7881,9 @@ FORCE_INLINE int64_t vget_lane_s64(int64x1_t a, const int b) {
   return __riscv_vmv_x_s_i64m1_i64(__riscv_vslidedown_vx_i64m1(a, b, 1));
 }
 
-// FORCE_INLINE poly8_t vget_lane_p8(poly8x8_t v, const int lane);
+FORCE_INLINE poly8_t vget_lane_p8(poly8x8_t v, const int lane) { return vget_lane_u8(v, lane); }
 
-// FORCE_INLINE poly16_t vget_lane_p16(poly16x4_t v, const int lane);
+FORCE_INLINE poly16_t vget_lane_p16(poly16x4_t v, const int lane) { return vget_lane_u16(v, lane); }
 
 FORCE_INLINE uint64_t vget_lane_u64(uint64x1_t a, const int b) {
   return __riscv_vmv_x_s_u64m1_u64(__riscv_vslidedown_vx_u64m1(a, b, 1));
@@ -7607,9 +7927,9 @@ FORCE_INLINE int64_t vgetq_lane_s64(int64x2_t a, const int b) {
   return __riscv_vmv_x_s_i64m1_i64(__riscv_vslidedown_vx_i64m1(a, b, 2));
 }
 
-// FORCE_INLINE poly8_t vgetq_lane_p8(poly8x16_t v, const int lane);
+FORCE_INLINE poly8_t vgetq_lane_p8(poly8x16_t v, const int lane) { return vgetq_lane_u8(v, lane); }
 
-// FORCE_INLINE poly16_t vgetq_lane_p16(poly16x8_t v, const int lane);
+FORCE_INLINE poly16_t vgetq_lane_p16(poly16x8_t v, const int lane) { return vgetq_lane_u16(v, lane); }
 
 // FORCE_INLINE float16_t vget_lane_f16(float16x4_t v, const int lane);
 
@@ -7666,9 +7986,9 @@ FORCE_INLINE int64x1_t vset_lane_s64(int64_t a, int64x1_t b, const int c) {
   return __riscv_vmerge_vxm_i64m1(b, a, mask, 1);
 }
 
-// FORCE_INLINE poly8x8_t vset_lane_p8(poly8_t a, poly8x8_t v, const int lane);
+FORCE_INLINE poly8x8_t vset_lane_p8(poly8_t a, poly8x8_t v, const int lane) { return vset_lane_u8(a, v, lane); }
 
-// FORCE_INLINE poly16x4_t vset_lane_p16(poly16_t a, poly16x4_t v, const int lane);
+FORCE_INLINE poly16x4_t vset_lane_p16(poly16_t a, poly16x4_t v, const int lane) { return vset_lane_u16(a, v, lane); }
 
 // FORCE_INLINE float16x4_t vset_lane_f16(float16_t a, float16x4_t v, const int lane);
 
@@ -7762,9 +8082,9 @@ FORCE_INLINE int64x2_t vsetq_lane_s64(int64_t a, int64x2_t b, const int c) {
   return __riscv_vmerge_vxm_i64m1(b, a, mask, 2);
 }
 
-// FORCE_INLINE poly8x16_t vsetq_lane_p8(poly8_t a, poly8x16_t v, const int lane);
+FORCE_INLINE poly8x16_t vsetq_lane_p8(poly8_t a, poly8x16_t v, const int lane) { return vsetq_lane_u8(a, v, lane); }
 
-// FORCE_INLINE poly16x8_t vsetq_lane_p16(poly16_t a, poly16x8_t v, const int lane);
+FORCE_INLINE poly16x8_t vsetq_lane_p16(poly16_t a, poly16x8_t v, const int lane) { return vsetq_lane_u16(a, v, lane); }
 
 FORCE_INLINE uint64x2_t vsetq_lane_u64(uint64_t a, uint64x2_t b, const int c) {
   vbool64_t mask = __riscv_vreinterpret_v_u64m1_b64(vdup_n_u64((uint64_t)(1 << c)));
@@ -7794,9 +8114,15 @@ FORCE_INLINE float32x2_t vcreate_f32(uint64_t a) {
       __riscv_vreinterpret_v_i64m1_i32m1(__riscv_vreinterpret_v_u64m1_i64m1(__riscv_vmv_v_x_u64m1(a, 8))));
 }
 
-// FORCE_INLINE poly8x8_t vcreate_p8(uint64_t a);
+FORCE_INLINE poly8x8_t vcreate_p8(uint64_t a) {
+  return __riscv_vreinterpret_v_u64m1_u8m1(
+      __riscv_vreinterpret_v_i64m1_u64m1(__riscv_vreinterpret_v_u64m1_i64m1(__riscv_vmv_v_x_u64m1(a, 8))));
+}
 
-// FORCE_INLINE poly16x4_t vcreate_p16(uint64_t a);
+FORCE_INLINE poly16x4_t vcreate_p16(uint64_t a) {
+  return __riscv_vreinterpret_v_u64m1_u16m1(
+      __riscv_vreinterpret_v_i64m1_u64m1(__riscv_vreinterpret_v_u64m1_i64m1(__riscv_vmv_v_x_u64m1(a, 8))));
+}
 
 FORCE_INLINE float64x1_t vcreate_f64(uint64_t a) {
   return __riscv_vreinterpret_v_u64m1_f64m1(__riscv_vmv_v_x_u64m1(a, 8));
@@ -7949,13 +8275,15 @@ FORCE_INLINE int32x4_t vdupq_lane_s32(int32x2_t a, const int b) { return __riscv
 
 FORCE_INLINE float32x4_t vdupq_lane_f32(float32x2_t a, const int b) { return __riscv_vrgather_vx_f32m1(a, b, 4); }
 
-// FORCE_INLINE poly8x8_t vdup_lane_p8(poly8x8_t vec, const int lane);
+FORCE_INLINE poly8x8_t vdup_lane_p8(poly8x8_t vec, const int lane) { return vdup_lane_u8(vec, lane); }
 
-// FORCE_INLINE poly8x16_t vdupq_lane_p8(poly8x8_t vec, const int lane);
+FORCE_INLINE poly8x16_t vdupq_lane_p8(poly8x8_t vec, const int lane) { return __riscv_vrgather_vx_u8m1(vec, lane, 16); }
 
-// FORCE_INLINE poly16x4_t vdup_lane_p16(poly16x4_t vec, const int lane);
+FORCE_INLINE poly16x4_t vdup_lane_p16(poly16x4_t vec, const int lane) { return vdup_lane_u16(vec, lane); }
 
-// FORCE_INLINE poly16x8_t vdupq_lane_p16(poly16x4_t vec, const int lane);
+FORCE_INLINE poly16x8_t vdupq_lane_p16(poly16x4_t vec, const int lane) {
+  return __riscv_vrgather_vx_u16m1(vec, lane, 8);
+}
 
 FORCE_INLINE float64x1_t vdup_lane_f64(float64x1_t a, const int b) { return __riscv_vrgather_vx_f64m1(a, b, 1); }
 
@@ -8037,9 +8365,13 @@ FORCE_INLINE int64x2_t vcombine_s64(int64x1_t a, int64x1_t b) { return __riscv_v
 
 FORCE_INLINE float32x4_t vcombine_f32(float32x2_t a, float32x2_t b) { return __riscv_vslideup_vx_f32m1(a, b, 2, 4); }
 
-// FORCE_INLINE poly8x16_t vcombine_p8(poly8x8_t low, poly8x8_t high);
+FORCE_INLINE poly8x16_t vcombine_p8(poly8x8_t low, poly8x8_t high) {
+  return __riscv_vslideup_vx_u8m1(low, high, 8, 16);
+}
 
-// FORCE_INLINE poly16x8_t vcombine_p16(poly16x4_t low, poly16x4_t high);
+FORCE_INLINE poly16x8_t vcombine_p16(poly16x4_t low, poly16x4_t high) {
+  return __riscv_vslideup_vx_u16m1(low, high, 4, 8);
+}
 
 FORCE_INLINE float64x2_t vcombine_f64(float64x1_t a, float64x1_t b) { return __riscv_vslideup_vx_f64m1(a, b, 1, 2); }
 
@@ -8065,15 +8397,15 @@ FORCE_INLINE int64x1_t vget_high_s64(int64x2_t a) { return __riscv_vslidedown_vx
 
 FORCE_INLINE float32x2_t vget_high_f32(float32x4_t a) { return __riscv_vslidedown_vx_f32m1(a, 2, 4); }
 
-// FORCE_INLINE poly8x8_t vget_high_p8(poly8x16_t a);
-
-// FORCE_INLINE poly16x4_t vget_high_p16(poly16x8_t a);
-
 FORCE_INLINE float64x1_t vget_high_f64(float64x2_t a) { return __riscv_vslidedown_vx_f64m1(a, 1, 2); }
 
 FORCE_INLINE uint8x8_t vget_high_u8(uint8x16_t a) { return __riscv_vslidedown_vx_u8m1(a, 8, 16); }
 
 FORCE_INLINE uint16x4_t vget_high_u16(uint16x8_t a) { return __riscv_vslidedown_vx_u16m1(a, 4, 8); }
+
+FORCE_INLINE poly8x8_t vget_high_p8(poly8x16_t a) { return vget_high_u8(a); }
+
+FORCE_INLINE poly16x4_t vget_high_p16(poly16x8_t a) { return vget_high_u16(a); }
 
 FORCE_INLINE uint32x2_t vget_high_u32(uint32x4_t a) { return __riscv_vslidedown_vx_u32m1(a, 2, 4); }
 
@@ -8091,9 +8423,9 @@ FORCE_INLINE int32x2_t vget_low_s32(int32x4_t a) { return a; }
 
 FORCE_INLINE float32x2_t vget_low_f32(float32x4_t a) { return a; }
 
-// FORCE_INLINE poly8x8_t vget_low_p8(poly8x16_t a);
+FORCE_INLINE poly8x8_t vget_low_p8(poly8x16_t a) { return a; }
 
-// FORCE_INLINE poly16x4_t vget_low_p16(poly16x8_t a);
+FORCE_INLINE poly16x4_t vget_low_p16(poly16x8_t a) { return a; }
 
 FORCE_INLINE float64x1_t vget_low_f64(float64x2_t a) { return a; }
 
@@ -8342,17 +8674,35 @@ FORCE_INLINE int32x2_t vcvt_n_s32_f32(float32x2_t a, const int b) {
   return __riscv_vfcvt_rtz_x_f_v_i32m1(a_mul_pow2_b, 2);
 }
 
-// FORCE_INLINE float32x2_t vcvt_n_f32_s32(int32x2_t a, const int b);
+FORCE_INLINE float32x2_t vcvt_n_f32_s32(int32x2_t a, const int b) {
+  vfloat32m1_t f = __riscv_vfcvt_f_x_v_f32m1(a, 2);
+  return __riscv_vfmul_vf_f32m1(f, 1.0f / (float)(1u << b), 2);
+}
 
-// FORCE_INLINE float32x2_t vcvt_n_f32_u32(uint32x2_t a, const int b);
+FORCE_INLINE float32x2_t vcvt_n_f32_u32(uint32x2_t a, const int b) {
+  vfloat32m1_t f = __riscv_vfcvt_f_xu_v_f32m1(a, 2);
+  return __riscv_vfmul_vf_f32m1(f, 1.0f / (float)(1u << b), 2);
+}
 
-// FORCE_INLINE uint32x2_t vcvt_n_u32_f32(float32x2_t a, const int b);
+FORCE_INLINE uint32x2_t vcvt_n_u32_f32(float32x2_t a, const int b) {
+  vfloat32m1_t a_mul = __riscv_vfmul_vf_f32m1(a, (float)(1u << b), 2);
+  return __riscv_vfcvt_rtz_xu_f_v_u32m1(a_mul, 2);
+}
 
-// FORCE_INLINE int32x4_t vcvtq_n_s32_f32(float32x4_t a, const int b);
+FORCE_INLINE int32x4_t vcvtq_n_s32_f32(float32x4_t a, const int b) {
+  vfloat32m1_t a_mul = __riscv_vfmul_vf_f32m1(a, (float)(1u << b), 4);
+  return __riscv_vfcvt_rtz_x_f_v_i32m1(a_mul, 4);
+}
 
-// FORCE_INLINE float32x4_t vcvtq_n_f32_s32(int32x4_t a, const int b);
+FORCE_INLINE float32x4_t vcvtq_n_f32_s32(int32x4_t a, const int b) {
+  vfloat32m1_t f = __riscv_vfcvt_f_x_v_f32m1(a, 4);
+  return __riscv_vfmul_vf_f32m1(f, 1.0f / (float)(1u << b), 4);
+}
 
-// FORCE_INLINE float32x4_t vcvtq_n_f32_u32(uint32x4_t a, const int b);
+FORCE_INLINE float32x4_t vcvtq_n_f32_u32(uint32x4_t a, const int b) {
+  vfloat32m1_t f = __riscv_vfcvt_f_xu_v_f32m1(a, 4);
+  return __riscv_vfmul_vf_f32m1(f, 1.0f / (float)(1u << b), 4);
+}
 
 // FORCE_INLINE float32_t vcvts_n_f32_s32(int32_t a, const int n);
 
@@ -8392,7 +8742,10 @@ FORCE_INLINE int32x2_t vcvt_n_s32_f32(float32x2_t a, const int b) {
 
 // FORCE_INLINE float32x4_t vcvtx_high_f32_f64(float32x2_t r, float64x2_t a);
 
-// FORCE_INLINE uint32x4_t vcvtq_n_u32_f32(float32x4_t a, const int b);
+FORCE_INLINE uint32x4_t vcvtq_n_u32_f32(float32x4_t a, const int b) {
+  vfloat32m1_t a_mul = __riscv_vfmul_vf_f32m1(a, (float)(1u << b), 4);
+  return __riscv_vfcvt_rtz_xu_f_v_u32m1(a_mul, 4);
+}
 
 // FORCE_INLINE int32_t vcvts_n_s32_f32(float32_t a, const int n);
 
@@ -11791,23 +12144,23 @@ FORCE_INLINE float64x2_t vextq_f64(float64x2_t a, float64x2_t b, const int c) {
   return __riscv_vslideup_vx_f64m1(a_slidedown, b, 2 - c, 2);
 }
 
-// FORCE_INLINE poly8x8_t vext_p8(poly8x8_t a, poly8x8_t b, const int n);
-
-// FORCE_INLINE poly8x16_t vextq_p8(poly8x16_t a, poly8x16_t b, const int n);
-
-// FORCE_INLINE poly16x4_t vext_p16(poly16x4_t a, poly16x4_t b, const int n);
-
-// FORCE_INLINE poly16x8_t vextq_p16(poly16x8_t a, poly16x8_t b, const int n);
+FORCE_INLINE poly8x8_t vext_p8(poly8x8_t a, poly8x8_t b, const int n) { return vext_u8(a, b, n); }
 
 FORCE_INLINE uint8x16_t vextq_u8(uint8x16_t a, uint8x16_t b, const int c) {
   vuint8m1_t a_slidedown = __riscv_vslidedown_vx_u8m1(a, c, 16);
   return __riscv_vslideup_vx_u8m1(a_slidedown, b, 16 - c, 16);
 }
 
+FORCE_INLINE poly8x16_t vextq_p8(poly8x16_t a, poly8x16_t b, const int n) { return vextq_u8(a, b, n); }
+
+FORCE_INLINE poly16x4_t vext_p16(poly16x4_t a, poly16x4_t b, const int n) { return vext_u16(a, b, n); }
+
 FORCE_INLINE uint16x8_t vextq_u16(uint16x8_t a, uint16x8_t b, const int c) {
   vuint16m1_t a_slidedown = __riscv_vslidedown_vx_u16m1(a, c, 8);
   return __riscv_vslideup_vx_u16m1(a_slidedown, b, 8 - c, 8);
 }
+
+FORCE_INLINE poly16x8_t vextq_p16(poly16x8_t a, poly16x8_t b, const int n) { return vextq_u16(a, b, n); }
 
 FORCE_INLINE uint32x4_t vextq_u32(uint32x4_t a, uint32x4_t b, const int c) {
   vuint32m1_t a_slidedown = __riscv_vslidedown_vx_u32m1(a, c, 4);
@@ -11900,13 +12253,7 @@ FORCE_INLINE float32x4_t vrev64q_f32(float32x4_t a) {
   return __riscv_vrgather_vv_f32m1(a, idxs, 4);
 }
 
-// FORCE_INLINE poly8x8_t vrev64_p8(poly8x8_t vec);
-
-// FORCE_INLINE poly8x16_t vrev64q_p8(poly8x16_t vec);
-
-// FORCE_INLINE poly16x4_t vrev64_p16(poly16x4_t vec);
-
-// FORCE_INLINE poly16x8_t vrev64q_p16(poly16x8_t vec);
+FORCE_INLINE poly8x8_t vrev64_p8(poly8x8_t vec) { return vrev64_u8(vec); }
 
 FORCE_INLINE uint8x16_t vrev64q_u8(uint8x16_t a) {
   vuint8m1_t vid = __riscv_vid_v_u8m1(8);
@@ -11916,6 +12263,10 @@ FORCE_INLINE uint8x16_t vrev64q_u8(uint8x16_t a) {
   return __riscv_vrgather_vv_u8m1(a, idxs, 16);
 }
 
+FORCE_INLINE poly8x16_t vrev64q_p8(poly8x16_t vec) { return vrev64q_u8(vec); }
+
+FORCE_INLINE poly16x4_t vrev64_p16(poly16x4_t vec) { return vrev64_u16(vec); }
+
 FORCE_INLINE uint16x8_t vrev64q_u16(uint16x8_t a) {
   vuint16m1_t vid = __riscv_vid_v_u16m1(4);
   vuint16m1_t vid_slideup = __riscv_vslideup_vx_u16m1(vid, vid, 4, 8);
@@ -11923,6 +12274,8 @@ FORCE_INLINE uint16x8_t vrev64q_u16(uint16x8_t a) {
   vuint16m1_t idxs = __riscv_vsub_vv_u16m1(sub, vid_slideup, 8);
   return __riscv_vrgather_vv_u16m1(a, idxs, 8);
 }
+
+FORCE_INLINE poly16x8_t vrev64q_p16(poly16x8_t vec) { return vrev64q_u16(vec); }
 
 FORCE_INLINE uint32x4_t vrev64q_u32(uint32x4_t a) {
   vuint32m1_t vid = __riscv_vid_v_u32m1(2);
@@ -12012,13 +12365,13 @@ FORCE_INLINE uint16x8_t vrev32q_u16(uint16x8_t a) {
   return __riscv_vrgather_vv_u16m1(a, idxs, 8);
 }
 
-// FORCE_INLINE poly8x8_t vrev32_p8(poly8x8_t vec);
+FORCE_INLINE poly8x8_t vrev32_p8(poly8x8_t vec) { return vrev32_u8(vec); }
 
-// FORCE_INLINE poly8x16_t vrev32q_p8(poly8x16_t vec);
+FORCE_INLINE poly8x16_t vrev32q_p8(poly8x16_t vec) { return vrev32q_u8(vec); }
 
-// FORCE_INLINE poly16x4_t vrev32_p16(poly16x4_t vec);
+FORCE_INLINE poly16x4_t vrev32_p16(poly16x4_t vec) { return vrev32_u16(vec); }
 
-// FORCE_INLINE poly16x8_t vrev32q_p16(poly16x8_t vec);
+FORCE_INLINE poly16x8_t vrev32q_p16(poly16x8_t vec) { return vrev32q_u16(vec); }
 
 FORCE_INLINE int8x8_t vrev16_s8(int8x8_t a) {
   vuint16m1_t a_u16 = __riscv_vreinterpret_v_u8m1_u16m1(__riscv_vreinterpret_v_i8m1_u8m1(a));
@@ -12048,9 +12401,9 @@ FORCE_INLINE uint8x16_t vrev16q_u8(uint8x16_t a) {
   return __riscv_vreinterpret_v_u16m1_u8m1(__riscv_vor_vv_u16m1(low, high, 16));
 }
 
-// FORCE_INLINE poly8x8_t vrev16_p8(poly8x8_t vec);
+FORCE_INLINE poly8x8_t vrev16_p8(poly8x8_t vec) { return vrev16_u8(vec); }
 
-// FORCE_INLINE poly8x16_t vrev16q_p8(poly8x16_t vec);
+FORCE_INLINE poly8x16_t vrev16q_p8(poly8x16_t vec) { return vrev16q_u8(vec); }
 
 // FORCE_INLINE int8x8_t vzip1_s8(int8x8_t a, int8x8_t b);
 
@@ -12429,13 +12782,17 @@ FORCE_INLINE float32x4_t vbslq_f32(uint32x4_t a, float32x4_t b, float32x4_t c) {
       __riscv_vxor_vv_u32m1(__riscv_vand_vv_u32m1(__riscv_vxor_vv_u32m1(c_u32, b_u32, 4), a, 4), c_u32, 4));
 }
 
-// FORCE_INLINE poly8x8_t vbsl_p8(uint8x8_t a, poly8x8_t b, poly8x8_t c);
+FORCE_INLINE poly8x8_t vbsl_p8(uint8x8_t a, poly8x8_t b, poly8x8_t c) { return vbsl_u8(a, b, c); }
 
-// FORCE_INLINE poly8x16_t vbslq_p8(uint8x16_t a, poly8x16_t b, poly8x16_t c);
+FORCE_INLINE poly8x16_t vbslq_p8(uint8x16_t a, poly8x16_t b, poly8x16_t c) {
+  return __riscv_vxor_vv_u8m1(__riscv_vand_vv_u8m1(__riscv_vxor_vv_u8m1(c, b, 16), a, 16), c, 16);
+}
 
-// FORCE_INLINE poly16x4_t vbsl_p16(uint16x4_t a, poly16x4_t b, poly16x4_t c);
+FORCE_INLINE poly16x4_t vbsl_p16(uint16x4_t a, poly16x4_t b, poly16x4_t c) { return vbsl_u16(a, b, c); }
 
-// FORCE_INLINE poly16x8_t vbslq_p16(uint16x8_t a, poly16x8_t b, poly16x8_t c);
+FORCE_INLINE poly16x8_t vbslq_p16(uint16x8_t a, poly16x8_t b, poly16x8_t c) {
+  return __riscv_vxor_vv_u16m1(__riscv_vand_vv_u16m1(__riscv_vxor_vv_u16m1(c, b, 8), a, 8), c, 8);
+}
 
 FORCE_INLINE float64x1_t vbsl_f64(uint64x1_t a, float64x1_t b, float64x1_t c) {
   vuint64m1_t b_u64 = __riscv_vreinterpret_v_f64m1_u64m1(b);
@@ -13369,13 +13726,23 @@ FORCE_INLINE float32x4_t vld1q_lane_f32(const float32_t *a, float32x4_t b, const
   return __riscv_vmerge_vvm_f32m1(b, a_dup, mask, 4);
 }
 
-// FORCE_INLINE poly8x8_t vld1_lane_p8(poly8_t const * ptr, poly8x8_t src, const int lane);
+FORCE_INLINE poly8x8_t vld1_lane_p8(poly8_t const *ptr, poly8x8_t src, const int lane) {
+  return vld1_lane_u8(ptr, src, lane);
+}
 
-// FORCE_INLINE poly8x16_t vld1q_lane_p8(poly8_t const * ptr, poly8x16_t src, const int lane);
+FORCE_INLINE poly8x16_t vld1q_lane_p8(poly8_t const *ptr, poly8x16_t src, const int lane) {
+  vbool8_t mask = __riscv_vreinterpret_v_u16m1_b8(vdup_n_u16((uint16_t)(1 << lane)));
+  return __riscv_vmerge_vvm_u8m1(src, vdupq_n_u8(ptr[0]), mask, 16);
+}
 
-// FORCE_INLINE poly16x4_t vld1_lane_p16(poly16_t const * ptr, poly16x4_t src, const int lane);
+FORCE_INLINE poly16x4_t vld1_lane_p16(poly16_t const *ptr, poly16x4_t src, const int lane) {
+  return vld1_lane_u16(ptr, src, lane);
+}
 
-// FORCE_INLINE poly16x8_t vld1q_lane_p16(poly16_t const * ptr, poly16x8_t src, const int lane);
+FORCE_INLINE poly16x8_t vld1q_lane_p16(poly16_t const *ptr, poly16x8_t src, const int lane) {
+  vbool16_t mask = __riscv_vreinterpret_v_u8m1_b16(vdup_n_u8((uint8_t)(1 << lane)));
+  return __riscv_vmerge_vvm_u16m1(src, vdupq_n_u16(ptr[0]), mask, 8);
+}
 
 FORCE_INLINE float64x1_t vld1_lane_f64(float64_t const *a, float64x1_t b, const int lane) {
   vbool64_t mask = __riscv_vreinterpret_v_u8m1_b64(vdup_n_u8((uint8_t)(1 << lane)));
@@ -13453,21 +13820,21 @@ FORCE_INLINE int32x4_t vld1q_dup_s32(const int32_t *a) { return vdupq_n_s32(a[0]
 
 FORCE_INLINE float32x4_t vld1q_dup_f32(const float32_t *a) { return vdupq_n_f32(a[0]); }
 
-// FORCE_INLINE poly8x8_t vld1_dup_p8(poly8_t const * ptr);
+FORCE_INLINE poly8x8_t vld1_dup_p8(poly8_t const *ptr) { return vld1_dup_u8(ptr); }
 
-// FORCE_INLINE poly8x16_t vld1q_dup_p8(poly8_t const * ptr);
+FORCE_INLINE uint8x16_t vld1q_dup_u8(const uint8_t *a) { return vdupq_n_u8(a[0]); }
 
-// FORCE_INLINE poly16x4_t vld1_dup_p16(poly16_t const * ptr);
+FORCE_INLINE poly8x16_t vld1q_dup_p8(poly8_t const *ptr) { return vld1q_dup_u8(ptr); }
 
-// FORCE_INLINE poly16x8_t vld1q_dup_p16(poly16_t const * ptr);
+FORCE_INLINE poly16x4_t vld1_dup_p16(poly16_t const *ptr) { return vld1_dup_u16(ptr); }
+
+FORCE_INLINE uint16x8_t vld1q_dup_u16(const uint16_t *a) { return vdupq_n_u16(a[0]); }
+
+FORCE_INLINE poly16x8_t vld1q_dup_p16(poly16_t const *ptr) { return vld1q_dup_u16(ptr); }
 
 FORCE_INLINE float64x1_t vld1_dup_f64(float64_t const *a) { return vdup_n_f64(a[0]); }
 
 FORCE_INLINE float64x2_t vld1q_dup_f64(float64_t const *a) { return vdupq_n_f64(a[0]); }
-
-FORCE_INLINE uint8x16_t vld1q_dup_u8(const uint8_t *a) { return vdupq_n_u8(a[0]); }
-
-FORCE_INLINE uint16x8_t vld1q_dup_u16(const uint16_t *a) { return vdupq_n_u16(a[0]); }
 
 FORCE_INLINE uint32x4_t vld1q_dup_u32(const uint32_t *a) { return vdupq_n_u32(a[0]); }
 
@@ -13752,7 +14119,9 @@ FORCE_INLINE uint8x8x2_t vld2_lane_u8(const uint8_t *a, uint8x8x2_t b, const int
   return __riscv_vcreate_v_u8m1x2(c0, c1);
 }
 
-FORCE_INLINE poly8x8x2_t vld2_lane_p8(const poly8_t *ptr, poly8x8x2_t src, const int lane) { return vld2_lane_u8(ptr, src, lane); }
+FORCE_INLINE poly8x8x2_t vld2_lane_p8(const poly8_t *ptr, poly8x8x2_t src, const int lane) {
+  return vld2_lane_u8(ptr, src, lane);
+}
 
 // FORCE_INLINE int8x16x2_t vld2q_lane_s8(int8_t const * ptr, int8x16x2_t src, const int lane);
 
@@ -13811,7 +14180,9 @@ FORCE_INLINE float32x4x2_t vld2q_lane_f32(const float32_t *a, float32x4x2_t b, c
   return __riscv_vcreate_v_f32m1x2(c0, c1);
 }
 
-FORCE_INLINE poly16x4x2_t vld2_lane_p16(const poly16_t *ptr, poly16x4x2_t src, const int lane) { return vld2_lane_u16(ptr, src, lane); }
+FORCE_INLINE poly16x4x2_t vld2_lane_p16(const poly16_t *ptr, poly16x4x2_t src, const int lane) {
+  return vld2_lane_u16(ptr, src, lane);
+}
 
 FORCE_INLINE poly16x8x2_t vld2q_lane_p16(const poly16_t *ptr, poly16x8x2_t src, const int lane) {
   vbool16_t mask = __riscv_vreinterpret_v_u16m1_b16(vdup_n_u16((uint8_t)(1 << lane)));
@@ -13862,23 +14233,21 @@ FORCE_INLINE float32x2x2_t vld2_dup_f32(const float32_t *a) {
 
 // FORCE_INLINE float32x4x2_t vld2q_dup_f32(float32_t const * ptr);
 
-// FORCE_INLINE poly8x8x2_t vld2_dup_p8(poly8_t const * ptr);
-
-// FORCE_INLINE poly8x16x2_t vld2q_dup_p8(poly8_t const * ptr);
-
-// FORCE_INLINE poly16x4x2_t vld2_dup_p16(poly16_t const * ptr);
-
-// FORCE_INLINE poly16x8x2_t vld2q_dup_p16(poly16_t const * ptr);
-
 FORCE_INLINE uint8x8x2_t vld2_dup_u8(const uint8_t *a) {
   return __riscv_vcreate_v_u8m1x2(vdup_n_u8(a[0]), vdup_n_u8(a[1]));
 }
 
-// FORCE_INLINE uint8x16x2_t vld2q_dup_u8(uint8_t const * ptr);
+FORCE_INLINE poly8x8x2_t vld2_dup_p8(poly8_t const *ptr) { return vld2_dup_u8(ptr); }
+
+// FORCE_INLINE poly8x16x2_t vld2q_dup_p8(poly8_t const * ptr);
 
 FORCE_INLINE uint16x4x2_t vld2_dup_u16(const uint16_t *a) {
   return __riscv_vcreate_v_u16m1x2(vdup_n_u16(a[0]), vdup_n_u16(a[1]));
 }
+
+FORCE_INLINE poly16x4x2_t vld2_dup_p16(poly16_t const *ptr) { return vld2_dup_u16(ptr); }
+
+// FORCE_INLINE poly16x8x2_t vld2q_dup_p16(poly16_t const * ptr);
 
 // FORCE_INLINE uint16x8x2_t vld2q_dup_u16(uint16_t const * ptr);
 
@@ -14211,7 +14580,9 @@ FORCE_INLINE uint8x8x3_t vld3_lane_u8(const uint8_t *a, uint8x8x3_t b, const int
   return __riscv_vcreate_v_u8m1x3(c0, c1, c2);
 }
 
-FORCE_INLINE poly8x8x3_t vld3_lane_p8(const poly8_t *ptr, poly8x8x3_t src, const int lane) { return vld3_lane_u8(ptr, src, lane); }
+FORCE_INLINE poly8x8x3_t vld3_lane_p8(const poly8_t *ptr, poly8x8x3_t src, const int lane) {
+  return vld3_lane_u8(ptr, src, lane);
+}
 
 // FORCE_INLINE int8x16x3_t vld3q_lane_s8(int8_t const * ptr, int8x16x3_t src, const int lane);
 
@@ -14275,7 +14646,9 @@ FORCE_INLINE float32x4x3_t vld3q_lane_f32(const float32_t *a, float32x4x3_t b, c
   return __riscv_vcreate_v_f32m1x3(c0, c1, c2);
 }
 
-FORCE_INLINE poly16x4x3_t vld3_lane_p16(const poly16_t *ptr, poly16x4x3_t src, const int lane) { return vld3_lane_u16(ptr, src, lane); }
+FORCE_INLINE poly16x4x3_t vld3_lane_p16(const poly16_t *ptr, poly16x4x3_t src, const int lane) {
+  return vld3_lane_u16(ptr, src, lane);
+}
 
 FORCE_INLINE poly16x8x3_t vld3q_lane_p16(const poly16_t *ptr, poly16x8x3_t src, const int lane) {
   vbool16_t mask = __riscv_vreinterpret_v_u8m1_b16(vdup_n_u8((uint8_t)(1 << lane)));
@@ -14329,14 +14702,6 @@ FORCE_INLINE float32x2x3_t vld3_dup_f32(const float32_t *a) {
 
 // FORCE_INLINE float32x4x3_t vld3q_dup_f32(float32_t const * ptr);
 
-// FORCE_INLINE poly8x8x3_t vld3_dup_p8(poly8_t const * ptr);
-
-// FORCE_INLINE poly8x16x3_t vld3q_dup_p8(poly8_t const * ptr);
-
-// FORCE_INLINE poly16x4x3_t vld3_dup_p16(poly16_t const * ptr);
-
-// FORCE_INLINE poly16x8x3_t vld3q_dup_p16(poly16_t const * ptr);
-
 FORCE_INLINE uint8x8x3_t vld3_dup_u8(const uint8_t *a) {
   return __riscv_vcreate_v_u8m1x3(vdup_n_u8(a[0]), vdup_n_u8(a[1]), vdup_n_u8(a[2]));
 }
@@ -14348,6 +14713,14 @@ FORCE_INLINE uint16x4x3_t vld3_dup_u16(const uint16_t *a) {
 }
 
 // FORCE_INLINE uint16x8x3_t vld3q_dup_u16(uint16_t const * ptr);
+
+FORCE_INLINE poly8x8x3_t vld3_dup_p8(poly8_t const *ptr) { return vld3_dup_u8(ptr); }
+
+// FORCE_INLINE poly8x16x3_t vld3q_dup_p8(poly8_t const * ptr);
+
+FORCE_INLINE poly16x4x3_t vld3_dup_p16(poly16_t const *ptr) { return vld3_dup_u16(ptr); }
+
+// FORCE_INLINE poly16x8x3_t vld3q_dup_p16(poly16_t const * ptr);
 
 FORCE_INLINE uint32x2x3_t vld3_dup_u32(const uint32_t *a) {
   return __riscv_vcreate_v_u32m1x3(vdup_n_u32(a[0]), vdup_n_u32(a[1]), vdup_n_u32(a[2]));
@@ -14417,17 +14790,17 @@ FORCE_INLINE void vst3q_s32(int32_t *a, int32x4x3_t b) { return __riscv_vsseg3e3
 
 FORCE_INLINE void vst3q_f32(float32_t *a, float32x4x3_t b) { return __riscv_vsseg3e32_v_f32m1x3(a, b, 4); }
 
-// FORCE_INLINE void vst3_p8(poly8_t * ptr, poly8x8x3_t val);
-
-// FORCE_INLINE void vst3q_p8(poly8_t * ptr, poly8x16x3_t val);
-
-// FORCE_INLINE void vst3_p16(poly16_t * ptr, poly16x4x3_t val);
-
-// FORCE_INLINE void vst3q_p16(poly16_t * ptr, poly16x8x3_t val);
+FORCE_INLINE void vst3_p8(poly8_t *ptr, poly8x8x3_t val) { vst3_u8(ptr, val); }
 
 FORCE_INLINE void vst3q_u8(uint8_t *a, uint8x16x3_t b) { return __riscv_vsseg3e8_v_u8m1x3(a, b, 16); }
 
 FORCE_INLINE void vst3q_u16(uint16_t *a, uint16x8x3_t b) { return __riscv_vsseg3e16_v_u16m1x3(a, b, 8); }
+
+FORCE_INLINE void vst3q_p8(poly8_t *ptr, poly8x16x3_t val) { vst3q_u8(ptr, val); }
+
+FORCE_INLINE void vst3_p16(poly16_t *ptr, poly16x4x3_t val) { vst3_u16(ptr, val); }
+
+FORCE_INLINE void vst3q_p16(poly16_t *ptr, poly16x8x3_t val) { vst3q_u16(ptr, val); }
 
 FORCE_INLINE void vst3q_u32(uint32_t *a, uint32x4x3_t b) { return __riscv_vsseg3e32_v_u32m1x3(a, b, 4); }
 
@@ -14722,7 +15095,9 @@ FORCE_INLINE uint8x8x4_t vld4_lane_u8(const uint8_t *a, uint8x8x4_t b, const int
   return __riscv_vcreate_v_u8m1x4(c0, c1, c2, c3);
 }
 
-FORCE_INLINE poly8x8x4_t vld4_lane_p8(const poly8_t *ptr, poly8x8x4_t src, const int lane) { return vld4_lane_u8(ptr, src, lane); }
+FORCE_INLINE poly8x8x4_t vld4_lane_p8(const poly8_t *ptr, poly8x8x4_t src, const int lane) {
+  return vld4_lane_u8(ptr, src, lane);
+}
 
 // FORCE_INLINE int8x16x4_t vld4q_lane_s8(int8_t const * ptr, int8x16x4_t src, const int lane);
 
@@ -14791,7 +15166,9 @@ FORCE_INLINE float32x4x4_t vld4q_lane_f32(const float32_t *a, float32x4x4_t b, c
   return __riscv_vcreate_v_f32m1x4(c0, c1, c2, c3);
 }
 
-FORCE_INLINE poly16x4x4_t vld4_lane_p16(const poly16_t *ptr, poly16x4x4_t src, const int lane) { return vld4_lane_u16(ptr, src, lane); }
+FORCE_INLINE poly16x4x4_t vld4_lane_p16(const poly16_t *ptr, poly16x4x4_t src, const int lane) {
+  return vld4_lane_u16(ptr, src, lane);
+}
 
 FORCE_INLINE poly16x8x4_t vld4q_lane_p16(const poly16_t *ptr, poly16x8x4_t src, const int lane) {
   vbool16_t mask = __riscv_vreinterpret_v_u8m1_b16(vdup_n_u8((uint8_t)(1 << lane)));
@@ -14848,14 +15225,6 @@ FORCE_INLINE float32x2x4_t vld4_dup_f32(const float32_t *a) {
 
 // FORCE_INLINE float32x4x4_t vld4q_dup_f32(float32_t const * ptr);
 
-// FORCE_INLINE poly8x8x4_t vld4_dup_p8(poly8_t const * ptr);
-
-// FORCE_INLINE poly8x16x4_t vld4q_dup_p8(poly8_t const * ptr);
-
-// FORCE_INLINE poly16x4x4_t vld4_dup_p16(poly16_t const * ptr);
-
-// FORCE_INLINE poly16x8x4_t vld4q_dup_p16(poly16_t const * ptr);
-
 FORCE_INLINE uint8x8x4_t vld4_dup_u8(const uint8_t *a) {
   return __riscv_vcreate_v_u8m1x4(vdup_n_u8(a[0]), vdup_n_u8(a[1]), vdup_n_u8(a[2]), vdup_n_u8(a[3]));
 }
@@ -14867,6 +15236,14 @@ FORCE_INLINE uint16x4x4_t vld4_dup_u16(const uint16_t *a) {
 }
 
 // FORCE_INLINE uint16x8x4_t vld4q_dup_u16(uint16_t const * ptr);
+
+FORCE_INLINE poly8x8x4_t vld4_dup_p8(poly8_t const *ptr) { return vld4_dup_u8(ptr); }
+
+// FORCE_INLINE poly8x16x4_t vld4q_dup_p8(poly8_t const * ptr);
+
+FORCE_INLINE poly16x4x4_t vld4_dup_p16(poly16_t const *ptr) { return vld4_dup_u16(ptr); }
+
+// FORCE_INLINE poly16x8x4_t vld4q_dup_p16(poly16_t const * ptr);
 
 FORCE_INLINE uint32x2x4_t vld4_dup_u32(const uint32_t *a) {
   return __riscv_vcreate_v_u32m1x4(vdup_n_u32(a[0]), vdup_n_u32(a[1]), vdup_n_u32(a[2]), vdup_n_u32(a[3]));
@@ -14936,17 +15313,17 @@ FORCE_INLINE void vst4q_s32(int32_t *a, int32x4x4_t b) { return __riscv_vsseg4e3
 
 FORCE_INLINE void vst4q_f32(float32_t *a, float32x4x4_t b) { return __riscv_vsseg4e32_v_f32m1x4(a, b, 4); }
 
-// FORCE_INLINE void vst4_p8(poly8_t * ptr, poly8x8x4_t val);
-
-// FORCE_INLINE void vst4q_p8(poly8_t * ptr, poly8x16x4_t val);
-
-// FORCE_INLINE void vst4_p16(poly16_t * ptr, poly16x4x4_t val);
-
-// FORCE_INLINE void vst4q_p16(poly16_t * ptr, poly16x8x4_t val);
+FORCE_INLINE void vst4_p8(poly8_t *ptr, poly8x8x4_t val) { vst4_u8(ptr, val); }
 
 FORCE_INLINE void vst4q_u8(uint8_t *a, uint8x16x4_t b) { return __riscv_vsseg4e8_v_u8m1x4(a, b, 16); }
 
 FORCE_INLINE void vst4q_u16(uint16_t *a, uint16x8x4_t b) { return __riscv_vsseg4e16_v_u16m1x4(a, b, 8); }
+
+FORCE_INLINE void vst4q_p8(poly8_t *ptr, poly8x16x4_t val) { vst4q_u8(ptr, val); }
+
+FORCE_INLINE void vst4_p16(poly16_t *ptr, poly16x4x4_t val) { vst4_u16(ptr, val); }
+
+FORCE_INLINE void vst4q_p16(poly16_t *ptr, poly16x8x4_t val) { vst4q_u16(ptr, val); }
 
 FORCE_INLINE void vst4q_u32(uint32_t *a, uint32x4x4_t b) { return __riscv_vsseg4e32_v_u32m1x4(a, b, 4); }
 
@@ -15969,53 +16346,61 @@ FORCE_INLINE float64x1_t vreinterpret_f64_u32(uint32x2_t a) {
 
 // FORCE_INLINE float16x4_t vreinterpret_f16_u32(uint32x2_t a);
 
-// FORCE_INLINE int8x8_t vreinterpret_s8_p8(poly8x8_t a);
+FORCE_INLINE int8x8_t vreinterpret_s8_p8(poly8x8_t a) { return __riscv_vreinterpret_v_u8m1_i8m1(a); }
 
-// FORCE_INLINE int16x4_t vreinterpret_s16_p8(poly8x8_t a);
+FORCE_INLINE int16x4_t vreinterpret_s16_p8(poly8x8_t a) {
+  return __riscv_vreinterpret_v_i8m1_i16m1(__riscv_vreinterpret_v_u8m1_i8m1(a));
+}
 
-// FORCE_INLINE int32x2_t vreinterpret_s32_p8(poly8x8_t a);
+FORCE_INLINE int32x2_t vreinterpret_s32_p8(poly8x8_t a) {
+  return __riscv_vreinterpret_v_i8m1_i32m1(__riscv_vreinterpret_v_u8m1_i8m1(a));
+}
 
-// FORCE_INLINE float32x2_t vreinterpret_f32_p8(poly8x8_t a);
+FORCE_INLINE float32x2_t vreinterpret_f32_p8(poly8x8_t a) { return vreinterpret_f32_u8(a); }
 
-// FORCE_INLINE uint8x8_t vreinterpret_u8_p8(poly8x8_t a);
+FORCE_INLINE uint8x8_t vreinterpret_u8_p8(poly8x8_t a) { return a; }
 
-// FORCE_INLINE uint16x4_t vreinterpret_u16_p8(poly8x8_t a);
+FORCE_INLINE uint16x4_t vreinterpret_u16_p8(poly8x8_t a) { return __riscv_vreinterpret_v_u8m1_u16m1(a); }
 
-// FORCE_INLINE uint32x2_t vreinterpret_u32_p8(poly8x8_t a);
+FORCE_INLINE uint32x2_t vreinterpret_u32_p8(poly8x8_t a) { return __riscv_vreinterpret_v_u8m1_u32m1(a); }
 
-// FORCE_INLINE poly16x4_t vreinterpret_p16_p8(poly8x8_t a);
+FORCE_INLINE poly16x4_t vreinterpret_p16_p8(poly8x8_t a) { return __riscv_vreinterpret_v_u8m1_u16m1(a); }
 
-// FORCE_INLINE uint64x1_t vreinterpret_u64_p8(poly8x8_t a);
+FORCE_INLINE uint64x1_t vreinterpret_u64_p8(poly8x8_t a) { return __riscv_vreinterpret_v_u8m1_u64m1(a); }
 
-// FORCE_INLINE int64x1_t vreinterpret_s64_p8(poly8x8_t a);
+FORCE_INLINE int64x1_t vreinterpret_s64_p8(poly8x8_t a) { return vreinterpret_s64_u8(a); }
 
-// FORCE_INLINE float64x1_t vreinterpret_f64_p8(poly8x8_t a);
+FORCE_INLINE float64x1_t vreinterpret_f64_p8(poly8x8_t a) { return vreinterpret_f64_u8(a); }
 
 // FORCE_INLINE poly64x1_t vreinterpret_p64_p8(poly8x8_t a);
 
 // FORCE_INLINE float16x4_t vreinterpret_f16_p8(poly8x8_t a);
 
-// FORCE_INLINE int8x8_t vreinterpret_s8_p16(poly16x4_t a);
+FORCE_INLINE int8x8_t vreinterpret_s8_p16(poly16x4_t a) {
+  return __riscv_vreinterpret_v_i16m1_i8m1(__riscv_vreinterpret_v_u16m1_i16m1(a));
+}
 
-// FORCE_INLINE int16x4_t vreinterpret_s16_p16(poly16x4_t a);
+FORCE_INLINE int16x4_t vreinterpret_s16_p16(poly16x4_t a) { return __riscv_vreinterpret_v_u16m1_i16m1(a); }
 
-// FORCE_INLINE int32x2_t vreinterpret_s32_p16(poly16x4_t a);
+FORCE_INLINE int32x2_t vreinterpret_s32_p16(poly16x4_t a) {
+  return __riscv_vreinterpret_v_i16m1_i32m1(__riscv_vreinterpret_v_u16m1_i16m1(a));
+}
 
-// FORCE_INLINE float32x2_t vreinterpret_f32_p16(poly16x4_t a);
+FORCE_INLINE float32x2_t vreinterpret_f32_p16(poly16x4_t a) { return vreinterpret_f32_u16(a); }
 
-// FORCE_INLINE uint8x8_t vreinterpret_u8_p16(poly16x4_t a);
+FORCE_INLINE uint8x8_t vreinterpret_u8_p16(poly16x4_t a) { return __riscv_vreinterpret_v_u16m1_u8m1(a); }
 
-// FORCE_INLINE uint16x4_t vreinterpret_u16_p16(poly16x4_t a);
+FORCE_INLINE uint16x4_t vreinterpret_u16_p16(poly16x4_t a) { return a; }
 
-// FORCE_INLINE uint32x2_t vreinterpret_u32_p16(poly16x4_t a);
+FORCE_INLINE uint32x2_t vreinterpret_u32_p16(poly16x4_t a) { return __riscv_vreinterpret_v_u16m1_u32m1(a); }
 
-// FORCE_INLINE poly8x8_t vreinterpret_p8_p16(poly16x4_t a);
+FORCE_INLINE poly8x8_t vreinterpret_p8_p16(poly16x4_t a) { return __riscv_vreinterpret_v_u16m1_u8m1(a); }
 
-// FORCE_INLINE uint64x1_t vreinterpret_u64_p16(poly16x4_t a);
+FORCE_INLINE uint64x1_t vreinterpret_u64_p16(poly16x4_t a) { return __riscv_vreinterpret_v_u16m1_u64m1(a); }
 
-// FORCE_INLINE int64x1_t vreinterpret_s64_p16(poly16x4_t a);
+FORCE_INLINE int64x1_t vreinterpret_s64_p16(poly16x4_t a) { return vreinterpret_s64_u16(a); }
 
-// FORCE_INLINE float64x1_t vreinterpret_f64_p16(poly16x4_t a);
+FORCE_INLINE float64x1_t vreinterpret_f64_p16(poly16x4_t a) { return vreinterpret_f64_u16(a); }
 
 // FORCE_INLINE poly64x1_t vreinterpret_p64_p16(poly16x4_t a);
 
@@ -16195,63 +16580,63 @@ FORCE_INLINE uint16x4_t vreinterpret_u16_u8(uint8x8_t a) { return __riscv_vreint
 
 FORCE_INLINE uint16x4_t vreinterpret_u16_u32(uint32x2_t a) { return __riscv_vreinterpret_v_u32m1_u16m1(a); }
 
-// FORCE_INLINE poly8x8_t vreinterpret_p8_u32(uint32x2_t a);
+FORCE_INLINE poly8x8_t vreinterpret_p8_u32(uint32x2_t a) { return vreinterpret_u8_u32(a); }
 
-// FORCE_INLINE poly16x4_t vreinterpret_p16_u32(uint32x2_t a);
+FORCE_INLINE poly16x4_t vreinterpret_p16_u32(uint32x2_t a) { return vreinterpret_u16_u32(a); }
 
 FORCE_INLINE uint32x2_t vreinterpret_u32_f32(float32x2_t a) { return __riscv_vreinterpret_v_f32m1_u32m1(a); }
 
-// FORCE_INLINE poly8x8_t vreinterpret_p8_f32(float32x2_t a);
+FORCE_INLINE poly8x8_t vreinterpret_p8_f32(float32x2_t a) { return vreinterpret_u8_f32(a); }
 
-// FORCE_INLINE poly16x4_t vreinterpret_p16_f32(float32x2_t a);
+FORCE_INLINE poly16x4_t vreinterpret_p16_f32(float32x2_t a) { return vreinterpret_u16_f32(a); }
 
 FORCE_INLINE uint32x2_t vreinterpret_u32_s64(int64x1_t a) {
   return __riscv_vreinterpret_v_u64m1_u32m1(__riscv_vreinterpret_v_i64m1_u64m1(a));
 }
 
-// FORCE_INLINE poly8x8_t vreinterpret_p8_s64(int64x1_t a);
+FORCE_INLINE poly8x8_t vreinterpret_p8_s64(int64x1_t a) { return vreinterpret_u8_s64(a); }
 
-// FORCE_INLINE poly16x4_t vreinterpret_p16_s64(int64x1_t a);
+FORCE_INLINE poly16x4_t vreinterpret_p16_s64(int64x1_t a) { return vreinterpret_u16_s64(a); }
 
 FORCE_INLINE uint32x2_t vreinterpret_u32_u64(uint64x1_t a) { return __riscv_vreinterpret_v_u64m1_u32m1(a); }
 
-// FORCE_INLINE poly8x8_t vreinterpret_p8_u64(uint64x1_t a);
+FORCE_INLINE poly8x8_t vreinterpret_p8_u64(uint64x1_t a) { return vreinterpret_u8_u64(a); }
 
-// FORCE_INLINE poly16x4_t vreinterpret_p16_u64(uint64x1_t a);
+FORCE_INLINE poly16x4_t vreinterpret_p16_u64(uint64x1_t a) { return vreinterpret_u16_u64(a); }
 
 FORCE_INLINE uint32x2_t vreinterpret_u32_s8(int8x8_t a) {
   return __riscv_vreinterpret_v_u8m1_u32m1(__riscv_vreinterpret_v_i8m1_u8m1(a));
 }
 
-// FORCE_INLINE poly8x8_t vreinterpret_p8_s8(int8x8_t a);
+FORCE_INLINE poly8x8_t vreinterpret_p8_s8(int8x8_t a) { return vreinterpret_u8_s8(a); }
 
-// FORCE_INLINE poly16x4_t vreinterpret_p16_s8(int8x8_t a);
+FORCE_INLINE poly16x4_t vreinterpret_p16_s8(int8x8_t a) { return vreinterpret_u16_s8(a); }
 
 FORCE_INLINE uint32x2_t vreinterpret_u32_s16(int16x4_t a) {
   return __riscv_vreinterpret_v_u16m1_u32m1(__riscv_vreinterpret_v_i16m1_u16m1(a));
 }
 
-// FORCE_INLINE poly8x8_t vreinterpret_p8_s16(int16x4_t a);
+FORCE_INLINE poly8x8_t vreinterpret_p8_s16(int16x4_t a) { return vreinterpret_u8_s16(a); }
 
-// FORCE_INLINE poly16x4_t vreinterpret_p16_s16(int16x4_t a);
+FORCE_INLINE poly16x4_t vreinterpret_p16_s16(int16x4_t a) { return vreinterpret_u16_s16(a); }
 
 FORCE_INLINE uint32x2_t vreinterpret_u32_s32(int32x2_t a) { return __riscv_vreinterpret_v_i32m1_u32m1(a); }
 
-// FORCE_INLINE poly8x8_t vreinterpret_p8_s32(int32x2_t a);
+FORCE_INLINE poly8x8_t vreinterpret_p8_s32(int32x2_t a) { return vreinterpret_u8_s32(a); }
 
-// FORCE_INLINE poly16x4_t vreinterpret_p16_s32(int32x2_t a);
+FORCE_INLINE poly16x4_t vreinterpret_p16_s32(int32x2_t a) { return vreinterpret_u16_s32(a); }
 
 FORCE_INLINE uint32x2_t vreinterpret_u32_u8(uint8x8_t a) { return __riscv_vreinterpret_v_u8m1_u32m1(a); }
 
-// FORCE_INLINE poly8x8_t vreinterpret_p8_u8(uint8x8_t a);
+FORCE_INLINE poly8x8_t vreinterpret_p8_u8(uint8x8_t a) { return a; }
 
-// FORCE_INLINE poly16x4_t vreinterpret_p16_u8(uint8x8_t a);
+FORCE_INLINE poly16x4_t vreinterpret_p16_u8(uint8x8_t a) { return vreinterpret_u16_u8(a); }
 
 FORCE_INLINE uint32x2_t vreinterpret_u32_u16(uint16x4_t a) { return __riscv_vreinterpret_v_u16m1_u32m1(a); }
 
-// FORCE_INLINE poly8x8_t vreinterpret_p8_u16(uint16x4_t a);
+FORCE_INLINE poly8x8_t vreinterpret_p8_u16(uint16x4_t a) { return vreinterpret_u8_u16(a); }
 
-// FORCE_INLINE poly16x4_t vreinterpret_p16_u16(uint16x4_t a);
+FORCE_INLINE poly16x4_t vreinterpret_p16_u16(uint16x4_t a) { return a; }
 
 FORCE_INLINE float32x4_t vreinterpretq_f32_s64(int64x2_t a) {
   return __riscv_vreinterpret_v_i32m1_f32m1(__riscv_vreinterpret_v_i64m1_i32m1(a));
@@ -16393,27 +16778,31 @@ FORCE_INLINE float64x2_t vreinterpretq_f64_u32(uint32x4_t a) {
 
 // FORCE_INLINE float16x8_t vreinterpretq_f16_u32(uint32x4_t a);
 
-// FORCE_INLINE int8x16_t vreinterpretq_s8_p8(poly8x16_t a);
+FORCE_INLINE int8x16_t vreinterpretq_s8_p8(poly8x16_t a) { return __riscv_vreinterpret_v_u8m1_i8m1(a); }
 
-// FORCE_INLINE int16x8_t vreinterpretq_s16_p8(poly8x16_t a);
+FORCE_INLINE int16x8_t vreinterpretq_s16_p8(poly8x16_t a) {
+  return __riscv_vreinterpret_v_i8m1_i16m1(__riscv_vreinterpret_v_u8m1_i8m1(a));
+}
 
-// FORCE_INLINE int32x4_t vreinterpretq_s32_p8(poly8x16_t a);
+FORCE_INLINE int32x4_t vreinterpretq_s32_p8(poly8x16_t a) {
+  return __riscv_vreinterpret_v_i8m1_i32m1(__riscv_vreinterpret_v_u8m1_i8m1(a));
+}
 
-// FORCE_INLINE float32x4_t vreinterpretq_f32_p8(poly8x16_t a);
+FORCE_INLINE float32x4_t vreinterpretq_f32_p8(poly8x16_t a) { return vreinterpretq_f32_u8(a); }
 
-// FORCE_INLINE uint8x16_t vreinterpretq_u8_p8(poly8x16_t a);
+FORCE_INLINE uint8x16_t vreinterpretq_u8_p8(poly8x16_t a) { return a; }
 
-// FORCE_INLINE uint16x8_t vreinterpretq_u16_p8(poly8x16_t a);
+FORCE_INLINE uint16x8_t vreinterpretq_u16_p8(poly8x16_t a) { return __riscv_vreinterpret_v_u8m1_u16m1(a); }
 
-// FORCE_INLINE uint32x4_t vreinterpretq_u32_p8(poly8x16_t a);
+FORCE_INLINE uint32x4_t vreinterpretq_u32_p8(poly8x16_t a) { return __riscv_vreinterpret_v_u8m1_u32m1(a); }
 
-// FORCE_INLINE poly16x8_t vreinterpretq_p16_p8(poly8x16_t a);
+FORCE_INLINE poly16x8_t vreinterpretq_p16_p8(poly8x16_t a) { return __riscv_vreinterpret_v_u8m1_u16m1(a); }
 
-// FORCE_INLINE uint64x2_t vreinterpretq_u64_p8(poly8x16_t a);
+FORCE_INLINE uint64x2_t vreinterpretq_u64_p8(poly8x16_t a) { return __riscv_vreinterpret_v_u8m1_u64m1(a); }
 
-// FORCE_INLINE int64x2_t vreinterpretq_s64_p8(poly8x16_t a);
+FORCE_INLINE int64x2_t vreinterpretq_s64_p8(poly8x16_t a) { return vreinterpretq_s64_u8(a); }
 
-// FORCE_INLINE float64x2_t vreinterpretq_f64_p8(poly8x16_t a);
+FORCE_INLINE float64x2_t vreinterpretq_f64_p8(poly8x16_t a) { return vreinterpretq_f64_u8(a); }
 
 // FORCE_INLINE poly64x2_t vreinterpretq_p64_p8(poly8x16_t a);
 
@@ -16421,27 +16810,31 @@ FORCE_INLINE float64x2_t vreinterpretq_f64_u32(uint32x4_t a) {
 
 // FORCE_INLINE float16x8_t vreinterpretq_f16_p8(poly8x16_t a);
 
-// FORCE_INLINE int8x16_t vreinterpretq_s8_p16(poly16x8_t a);
+FORCE_INLINE int8x16_t vreinterpretq_s8_p16(poly16x8_t a) {
+  return __riscv_vreinterpret_v_i16m1_i8m1(__riscv_vreinterpret_v_u16m1_i16m1(a));
+}
 
-// FORCE_INLINE int16x8_t vreinterpretq_s16_p16(poly16x8_t a);
+FORCE_INLINE int16x8_t vreinterpretq_s16_p16(poly16x8_t a) { return __riscv_vreinterpret_v_u16m1_i16m1(a); }
 
-// FORCE_INLINE int32x4_t vreinterpretq_s32_p16(poly16x8_t a);
+FORCE_INLINE int32x4_t vreinterpretq_s32_p16(poly16x8_t a) {
+  return __riscv_vreinterpret_v_i16m1_i32m1(__riscv_vreinterpret_v_u16m1_i16m1(a));
+}
 
-// FORCE_INLINE float32x4_t vreinterpretq_f32_p16(poly16x8_t a);
+FORCE_INLINE float32x4_t vreinterpretq_f32_p16(poly16x8_t a) { return vreinterpretq_f32_u16(a); }
 
-// FORCE_INLINE uint8x16_t vreinterpretq_u8_p16(poly16x8_t a);
+FORCE_INLINE uint8x16_t vreinterpretq_u8_p16(poly16x8_t a) { return __riscv_vreinterpret_v_u16m1_u8m1(a); }
 
-// FORCE_INLINE uint16x8_t vreinterpretq_u16_p16(poly16x8_t a);
+FORCE_INLINE uint16x8_t vreinterpretq_u16_p16(poly16x8_t a) { return a; }
 
-// FORCE_INLINE uint32x4_t vreinterpretq_u32_p16(poly16x8_t a);
+FORCE_INLINE uint32x4_t vreinterpretq_u32_p16(poly16x8_t a) { return __riscv_vreinterpret_v_u16m1_u32m1(a); }
 
-// FORCE_INLINE poly8x16_t vreinterpretq_p8_p16(poly16x8_t a);
+FORCE_INLINE poly8x16_t vreinterpretq_p8_p16(poly16x8_t a) { return __riscv_vreinterpret_v_u16m1_u8m1(a); }
 
-// FORCE_INLINE uint64x2_t vreinterpretq_u64_p16(poly16x8_t a);
+FORCE_INLINE uint64x2_t vreinterpretq_u64_p16(poly16x8_t a) { return __riscv_vreinterpret_v_u16m1_u64m1(a); }
 
-// FORCE_INLINE int64x2_t vreinterpretq_s64_p16(poly16x8_t a);
+FORCE_INLINE int64x2_t vreinterpretq_s64_p16(poly16x8_t a) { return vreinterpretq_s64_u16(a); }
 
-// FORCE_INLINE float64x2_t vreinterpretq_f64_p16(poly16x8_t a);
+FORCE_INLINE float64x2_t vreinterpretq_f64_p16(poly16x8_t a) { return vreinterpretq_f64_u16(a); }
 
 // FORCE_INLINE poly64x2_t vreinterpretq_p64_p16(poly16x8_t a);
 
@@ -16511,9 +16904,9 @@ FORCE_INLINE uint32x2_t vreinterpret_u32_f64(float64x1_t a) {
   return __riscv_vreinterpret_v_u64m1_u32m1(__riscv_vreinterpret_v_f64m1_u64m1(a));
 }
 
-// FORCE_INLINE poly8x8_t vreinterpret_p8_f64(float64x1_t a);
+FORCE_INLINE poly8x8_t vreinterpret_p8_f64(float64x1_t a) { return vreinterpret_u8_f64(a); }
 
-// FORCE_INLINE poly16x4_t vreinterpret_p16_f64(float64x1_t a);
+FORCE_INLINE poly16x4_t vreinterpret_p16_f64(float64x1_t a) { return vreinterpret_u16_f64(a); }
 
 FORCE_INLINE uint64x1_t vreinterpret_u64_f64(float64x1_t a) { return __riscv_vreinterpret_v_f64m1_u64m1(a); }
 
@@ -16549,9 +16942,9 @@ FORCE_INLINE uint32x4_t vreinterpretq_u32_f64(float64x2_t a) {
   return __riscv_vreinterpret_v_u64m1_u32m1(__riscv_vreinterpret_v_f64m1_u64m1(a));
 }
 
-// FORCE_INLINE poly8x16_t vreinterpretq_p8_f64(float64x2_t a);
+FORCE_INLINE poly8x16_t vreinterpretq_p8_f64(float64x2_t a) { return vreinterpretq_u8_f64(a); }
 
-// FORCE_INLINE poly16x8_t vreinterpretq_p16_f64(float64x2_t a);
+FORCE_INLINE poly16x8_t vreinterpretq_p16_f64(float64x2_t a) { return vreinterpretq_u16_f64(a); }
 
 FORCE_INLINE uint64x2_t vreinterpretq_u64_f64(float64x2_t a) { return __riscv_vreinterpret_v_f64m1_u64m1(a); }
 
@@ -16771,63 +17164,63 @@ FORCE_INLINE uint16x8_t vreinterpretq_u16_u8(uint8x16_t a) { return __riscv_vrei
 
 FORCE_INLINE uint16x8_t vreinterpretq_u16_u32(uint32x4_t a) { return __riscv_vreinterpret_v_u32m1_u16m1(a); }
 
-// FORCE_INLINE poly8x16_t vreinterpretq_p8_u32(uint32x4_t a);
+FORCE_INLINE poly8x16_t vreinterpretq_p8_u32(uint32x4_t a) { return vreinterpretq_u8_u32(a); }
 
-// FORCE_INLINE poly16x8_t vreinterpretq_p16_u32(uint32x4_t a);
+FORCE_INLINE poly16x8_t vreinterpretq_p16_u32(uint32x4_t a) { return vreinterpretq_u16_u32(a); }
 
 FORCE_INLINE uint32x4_t vreinterpretq_u32_f32(float32x4_t a) { return __riscv_vreinterpret_v_f32m1_u32m1(a); }
 
-// FORCE_INLINE poly8x16_t vreinterpretq_p8_f32(float32x4_t a);
+FORCE_INLINE poly8x16_t vreinterpretq_p8_f32(float32x4_t a) { return vreinterpretq_u8_f32(a); }
 
-// FORCE_INLINE poly16x8_t vreinterpretq_p16_f32(float32x4_t a);
+FORCE_INLINE poly16x8_t vreinterpretq_p16_f32(float32x4_t a) { return vreinterpretq_u16_f32(a); }
 
 FORCE_INLINE uint32x4_t vreinterpretq_u32_s64(int64x2_t a) {
   return __riscv_vreinterpret_v_u64m1_u32m1(__riscv_vreinterpret_v_i64m1_u64m1(a));
 }
 
-// FORCE_INLINE poly8x16_t vreinterpretq_p8_s64(int64x2_t a);
+FORCE_INLINE poly8x16_t vreinterpretq_p8_s64(int64x2_t a) { return vreinterpretq_u8_s64(a); }
 
-// FORCE_INLINE poly16x8_t vreinterpretq_p16_s64(int64x2_t a);
+FORCE_INLINE poly16x8_t vreinterpretq_p16_s64(int64x2_t a) { return vreinterpretq_u16_s64(a); }
 
 FORCE_INLINE uint32x4_t vreinterpretq_u32_u64(uint64x2_t a) { return __riscv_vreinterpret_v_u64m1_u32m1(a); }
 
-// FORCE_INLINE poly8x16_t vreinterpretq_p8_u64(uint64x2_t a);
+FORCE_INLINE poly8x16_t vreinterpretq_p8_u64(uint64x2_t a) { return vreinterpretq_u8_u64(a); }
 
-// FORCE_INLINE poly16x8_t vreinterpretq_p16_u64(uint64x2_t a);
+FORCE_INLINE poly16x8_t vreinterpretq_p16_u64(uint64x2_t a) { return vreinterpretq_u16_u64(a); }
 
 FORCE_INLINE uint32x4_t vreinterpretq_u32_s8(int8x16_t a) {
   return __riscv_vreinterpret_v_u8m1_u32m1(__riscv_vreinterpret_v_i8m1_u8m1(a));
 }
 
-// FORCE_INLINE poly8x16_t vreinterpretq_p8_s8(int8x16_t a);
+FORCE_INLINE poly8x16_t vreinterpretq_p8_s8(int8x16_t a) { return vreinterpretq_u8_s8(a); }
 
-// FORCE_INLINE poly16x8_t vreinterpretq_p16_s8(int8x16_t a);
+FORCE_INLINE poly16x8_t vreinterpretq_p16_s8(int8x16_t a) { return vreinterpretq_u16_s8(a); }
 
 FORCE_INLINE uint32x4_t vreinterpretq_u32_s16(int16x8_t a) {
   return __riscv_vreinterpret_v_u16m1_u32m1(__riscv_vreinterpret_v_i16m1_u16m1(a));
 }
 
-// FORCE_INLINE poly8x16_t vreinterpretq_p8_s16(int16x8_t a);
+FORCE_INLINE poly8x16_t vreinterpretq_p8_s16(int16x8_t a) { return vreinterpretq_u8_s16(a); }
 
-// FORCE_INLINE poly16x8_t vreinterpretq_p16_s16(int16x8_t a);
+FORCE_INLINE poly16x8_t vreinterpretq_p16_s16(int16x8_t a) { return vreinterpretq_u16_s16(a); }
 
 FORCE_INLINE uint32x4_t vreinterpretq_u32_s32(int32x4_t a) { return __riscv_vreinterpret_v_i32m1_u32m1(a); }
 
-// FORCE_INLINE poly8x16_t vreinterpretq_p8_s32(int32x4_t a);
+FORCE_INLINE poly8x16_t vreinterpretq_p8_s32(int32x4_t a) { return vreinterpretq_u8_s32(a); }
 
-// FORCE_INLINE poly16x8_t vreinterpretq_p16_s32(int32x4_t a);
+FORCE_INLINE poly16x8_t vreinterpretq_p16_s32(int32x4_t a) { return vreinterpretq_u16_s32(a); }
 
 FORCE_INLINE uint32x4_t vreinterpretq_u32_u8(uint8x16_t a) { return __riscv_vreinterpret_v_u8m1_u32m1(a); }
 
-// FORCE_INLINE poly8x16_t vreinterpretq_p8_u8(uint8x16_t a);
+FORCE_INLINE poly8x16_t vreinterpretq_p8_u8(uint8x16_t a) { return a; }
 
-// FORCE_INLINE poly16x8_t vreinterpretq_p16_u8(uint8x16_t a);
+FORCE_INLINE poly16x8_t vreinterpretq_p16_u8(uint8x16_t a) { return vreinterpretq_u16_u8(a); }
 
 FORCE_INLINE uint32x4_t vreinterpretq_u32_u16(uint16x8_t a) { return __riscv_vreinterpret_v_u16m1_u32m1(a); }
 
-// FORCE_INLINE poly8x16_t vreinterpretq_p8_u16(uint16x8_t a);
+FORCE_INLINE poly8x16_t vreinterpretq_p8_u16(uint16x8_t a) { return vreinterpretq_u8_u16(a); }
 
-// FORCE_INLINE poly16x8_t vreinterpretq_p16_u16(uint16x8_t a);
+FORCE_INLINE poly16x8_t vreinterpretq_p16_u16(uint16x8_t a) { return a; }
 
 // FORCE_INLINE uint8x16_t vaeseq_u8(uint8x16_t __data, uint8x16_t __key);
 

--- a/neon2rvv.h
+++ b/neon2rvv.h
@@ -13265,11 +13265,11 @@ FORCE_INLINE float32x4_t vld1q_f32(const float32_t *ptr) { return __riscv_vle32_
 
 FORCE_INLINE poly8x8_t vld1_p8(const poly8_t *ptr) { return vld1_u8(ptr); }
 
-FORCE_INLINE poly8x16_t vld1q_p8(const poly8_t *ptr) { return vld1q_u8(ptr); }
+FORCE_INLINE poly8x16_t vld1q_p8(const poly8_t *ptr) { return __riscv_vle8_v_u8m1(ptr, 16); }
 
 FORCE_INLINE poly16x4_t vld1_p16(const poly16_t *ptr) { return vld1_u16(ptr); }
 
-FORCE_INLINE poly16x8_t vld1q_p16(const poly16_t *ptr) { return vld1q_u16(ptr); }
+FORCE_INLINE poly16x8_t vld1q_p16(const poly16_t *ptr) { return __riscv_vle16_v_u16m1(ptr, 8); }
 
 FORCE_INLINE float64x1_t vld1_f64(float64_t const *ptr) { return __riscv_vle64_v_f64m1(ptr, 1); }
 
@@ -13513,11 +13513,11 @@ FORCE_INLINE void vst1q_f32(float32_t *a, float32x4_t b) { __riscv_vse32_v_f32m1
 
 FORCE_INLINE void vst1_p8(poly8_t *ptr, poly8x8_t val) { vst1_u8(ptr, val); }
 
-FORCE_INLINE void vst1q_p8(poly8_t *ptr, poly8x16_t val) { vst1q_u8(ptr, val); }
+FORCE_INLINE void vst1q_p8(poly8_t *ptr, poly8x16_t val) { __riscv_vse8_v_u8m1(ptr, val, 16); }
 
 FORCE_INLINE void vst1_p16(poly16_t *ptr, poly16x4_t val) { vst1_u16(ptr, val); }
 
-FORCE_INLINE void vst1q_p16(poly16_t *ptr, poly16x8_t val) { vst1q_u16(ptr, val); }
+FORCE_INLINE void vst1q_p16(poly16_t *ptr, poly16x8_t val) { __riscv_vse16_v_u16m1(ptr, val, 8); }
 
 // FORCE_INLINE void vst1_f64(float64_t * ptr, float64x1_t val);
 
@@ -13606,11 +13606,17 @@ FORCE_INLINE void vst1q_lane_f32(float32_t *a, float32x4_t b, const int lane) {
 
 FORCE_INLINE void vst1_lane_p8(poly8_t *ptr, poly8x8_t val, const int lane) { vst1_lane_u8(ptr, val, lane); }
 
-FORCE_INLINE void vst1q_lane_p8(poly8_t *ptr, poly8x16_t val, const int lane) { vst1q_lane_u8(ptr, val, lane); }
+FORCE_INLINE void vst1q_lane_p8(poly8_t *ptr, poly8x16_t val, const int lane) {
+  vuint8m1_t val_s = __riscv_vslidedown_vx_u8m1(val, lane, 8);
+  *ptr = __riscv_vmv_x_s_u8m1_u8(val_s);
+}
 
 FORCE_INLINE void vst1_lane_p16(poly16_t *ptr, poly16x4_t val, const int lane) { vst1_lane_u16(ptr, val, lane); }
 
-FORCE_INLINE void vst1q_lane_p16(poly16_t *ptr, poly16x8_t val, const int lane) { vst1q_lane_u16(ptr, val, lane); }
+FORCE_INLINE void vst1q_lane_p16(poly16_t *ptr, poly16x8_t val, const int lane) {
+  vuint16m1_t val_s = __riscv_vslidedown_vx_u16m1(val, lane, 4);
+  *ptr = __riscv_vmv_x_s_u16m1_u16(val_s);
+}
 
 FORCE_INLINE void vst1_lane_f64(float64_t *a, float64x1_t b, const int lane) {
   vfloat64m1_t b_s = __riscv_vslidedown_vx_f64m1(b, lane, 1);
@@ -13695,11 +13701,11 @@ FORCE_INLINE float32x4x2_t vld2q_f32(const float32_t *a) { return __riscv_vlseg2
 
 FORCE_INLINE poly8x8x2_t vld2_p8(const poly8_t *ptr) { return vld2_u8(ptr); }
 
-FORCE_INLINE poly8x16x2_t vld2q_p8(const poly8_t *ptr) { return vld2q_u8(ptr); }
+FORCE_INLINE poly8x16x2_t vld2q_p8(const poly8_t *ptr) { return __riscv_vlseg2e8_v_u8m1x2(ptr, 16); }
 
 FORCE_INLINE poly16x4x2_t vld2_p16(const poly16_t *ptr) { return vld2_u16(ptr); }
 
-FORCE_INLINE poly16x8x2_t vld2q_p16(const poly16_t *ptr) { return vld2q_u16(ptr); }
+FORCE_INLINE poly16x8x2_t vld2q_p16(const poly16_t *ptr) { return __riscv_vlseg2e16_v_u16m1x2(ptr, 8); }
 
 FORCE_INLINE uint8x16x2_t vld2q_u8(const uint8_t *a) { return __riscv_vlseg2e8_v_u8m1x2(a, 16); }
 
@@ -13807,7 +13813,12 @@ FORCE_INLINE float32x4x2_t vld2q_lane_f32(const float32_t *a, float32x4x2_t b, c
 
 FORCE_INLINE poly16x4x2_t vld2_lane_p16(const poly16_t *ptr, poly16x4x2_t src, const int lane) { return vld2_lane_u16(ptr, src, lane); }
 
-FORCE_INLINE poly16x8x2_t vld2q_lane_p16(const poly16_t *ptr, poly16x8x2_t src, const int lane) { return vld2q_lane_u16(ptr, src, lane); }
+FORCE_INLINE poly16x8x2_t vld2q_lane_p16(const poly16_t *ptr, poly16x8x2_t src, const int lane) {
+  vbool16_t mask = __riscv_vreinterpret_v_u16m1_b16(vdup_n_u16((uint8_t)(1 << lane)));
+  vuint16m1_t c0 = __riscv_vmerge_vxm_u16m1(__riscv_vget_v_u16m1x2_u16m1(src, 0), ptr[0], mask, 8);
+  vuint16m1_t c1 = __riscv_vmerge_vxm_u16m1(__riscv_vget_v_u16m1x2_u16m1(src, 1), ptr[1], mask, 8);
+  return __riscv_vcreate_v_u16m1x2(c0, c1);
+}
 
 FORCE_INLINE uint16x8x2_t vld2q_lane_u16(const uint16_t *a, uint16x8x2_t b, const int c) {
   vbool16_t mask = __riscv_vreinterpret_v_u16m1_b16(vdup_n_u16((uint8_t)(1 << c)));
@@ -13941,11 +13952,11 @@ FORCE_INLINE void vst2q_f32(float32_t *a, float32x4x2_t b) { return __riscv_vsse
 
 FORCE_INLINE void vst2_p8(poly8_t *ptr, poly8x8x2_t val) { vst2_u8(ptr, val); }
 
-FORCE_INLINE void vst2q_p8(poly8_t *ptr, poly8x16x2_t val) { vst2q_u8(ptr, val); }
+FORCE_INLINE void vst2q_p8(poly8_t *ptr, poly8x16x2_t val) { __riscv_vsseg2e8_v_u8m1x2(ptr, val, 16); }
 
 FORCE_INLINE void vst2_p16(poly16_t *ptr, poly16x4x2_t val) { vst2_u16(ptr, val); }
 
-FORCE_INLINE void vst2q_p16(poly16_t *ptr, poly16x8x2_t val) { vst2q_u16(ptr, val); }
+FORCE_INLINE void vst2q_p16(poly16_t *ptr, poly16x8x2_t val) { __riscv_vsseg2e16_v_u16m1x2(ptr, val, 8); }
 
 FORCE_INLINE void vst2q_u8(uint8_t *a, uint8x16x2_t b) { return __riscv_vsseg2e8_v_u8m1x2(a, b, 16); }
 
@@ -14051,7 +14062,14 @@ FORCE_INLINE void vst2q_lane_f32(float32_t *a, float32x4x2_t b, const int c) {
 
 FORCE_INLINE void vst2_lane_p16(poly16_t *ptr, poly16x4x2_t val, const int lane) { vst2_lane_u16(ptr, val, lane); }
 
-FORCE_INLINE void vst2q_lane_p16(poly16_t *ptr, poly16x8x2_t val, const int lane) { vst2q_lane_u16(ptr, val, lane); }
+FORCE_INLINE void vst2q_lane_p16(poly16_t *ptr, poly16x8x2_t val, const int lane) {
+  vuint16m1_t b0 = __riscv_vget_v_u16m1x2_u16m1(val, 0);
+  vuint16m1_t b1 = __riscv_vget_v_u16m1x2_u16m1(val, 1);
+  uint16_t *_b0 = (uint16_t *)&b0;
+  uint16_t *_b1 = (uint16_t *)&b1;
+  ptr[0] = _b0[lane];
+  ptr[1] = _b1[lane];
+}
 
 // FORCE_INLINE void vst2q_lane_s8(int8_t * ptr, int8x16x2_t val, const int lane);
 
@@ -14137,11 +14155,11 @@ FORCE_INLINE float32x4x3_t vld3q_f32(const float32_t *a) { return __riscv_vlseg3
 
 FORCE_INLINE poly8x8x3_t vld3_p8(const poly8_t *ptr) { return vld3_u8(ptr); }
 
-FORCE_INLINE poly8x16x3_t vld3q_p8(const poly8_t *ptr) { return vld3q_u8(ptr); }
+FORCE_INLINE poly8x16x3_t vld3q_p8(const poly8_t *ptr) { return __riscv_vlseg3e8_v_u8m1x3(ptr, 16); }
 
 FORCE_INLINE poly16x4x3_t vld3_p16(const poly16_t *ptr) { return vld3_u16(ptr); }
 
-FORCE_INLINE poly16x8x3_t vld3q_p16(const poly16_t *ptr) { return vld3q_u16(ptr); }
+FORCE_INLINE poly16x8x3_t vld3q_p16(const poly16_t *ptr) { return __riscv_vlseg3e16_v_u16m1x3(ptr, 8); }
 
 FORCE_INLINE uint8x16x3_t vld3q_u8(const uint8_t *a) { return __riscv_vlseg3e8_v_u8m1x3(a, 16); }
 
@@ -14259,7 +14277,13 @@ FORCE_INLINE float32x4x3_t vld3q_lane_f32(const float32_t *a, float32x4x3_t b, c
 
 FORCE_INLINE poly16x4x3_t vld3_lane_p16(const poly16_t *ptr, poly16x4x3_t src, const int lane) { return vld3_lane_u16(ptr, src, lane); }
 
-FORCE_INLINE poly16x8x3_t vld3q_lane_p16(const poly16_t *ptr, poly16x8x3_t src, const int lane) { return vld3q_lane_u16(ptr, src, lane); }
+FORCE_INLINE poly16x8x3_t vld3q_lane_p16(const poly16_t *ptr, poly16x8x3_t src, const int lane) {
+  vbool16_t mask = __riscv_vreinterpret_v_u8m1_b16(vdup_n_u8((uint8_t)(1 << lane)));
+  vuint16m1_t c0 = __riscv_vmerge_vxm_u16m1(__riscv_vget_v_u16m1x3_u16m1(src, 0), ptr[0], mask, 8);
+  vuint16m1_t c1 = __riscv_vmerge_vxm_u16m1(__riscv_vget_v_u16m1x3_u16m1(src, 1), ptr[1], mask, 8);
+  vuint16m1_t c2 = __riscv_vmerge_vxm_u16m1(__riscv_vget_v_u16m1x3_u16m1(src, 2), ptr[2], mask, 8);
+  return __riscv_vcreate_v_u16m1x3(c0, c1, c2);
+}
 
 FORCE_INLINE uint16x8x3_t vld3q_lane_u16(const uint16_t *a, uint16x8x3_t b, const int c) {
   vbool16_t mask = __riscv_vreinterpret_v_u8m1_b16(vdup_n_u8((uint8_t)(1 << c)));
@@ -14535,7 +14559,17 @@ FORCE_INLINE void vst3q_lane_f32(float32_t *a, float32x4x3_t b, const int c) {
 
 FORCE_INLINE void vst3_lane_p16(poly16_t *ptr, poly16x4x3_t val, const int lane) { vst3_lane_u16(ptr, val, lane); }
 
-FORCE_INLINE void vst3q_lane_p16(poly16_t *ptr, poly16x8x3_t val, const int lane) { vst3q_lane_u16(ptr, val, lane); }
+FORCE_INLINE void vst3q_lane_p16(poly16_t *ptr, poly16x8x3_t val, const int lane) {
+  vuint16m1_t b0 = __riscv_vget_v_u16m1x3_u16m1(val, 0);
+  vuint16m1_t b1 = __riscv_vget_v_u16m1x3_u16m1(val, 1);
+  vuint16m1_t b2 = __riscv_vget_v_u16m1x3_u16m1(val, 2);
+  uint16_t *_b0 = (uint16_t *)&b0;
+  uint16_t *_b1 = (uint16_t *)&b1;
+  uint16_t *_b2 = (uint16_t *)&b2;
+  ptr[0] = _b0[lane];
+  ptr[1] = _b1[lane];
+  ptr[2] = _b2[lane];
+}
 
 // FORCE_INLINE void vst3q_lane_s8(int8_t * ptr, int8x16x3_t val, const int lane);
 
@@ -14627,11 +14661,11 @@ FORCE_INLINE float32x4x4_t vld4q_f32(const float32_t *a) { return __riscv_vlseg4
 
 FORCE_INLINE poly8x8x4_t vld4_p8(const poly8_t *ptr) { return vld4_u8(ptr); }
 
-FORCE_INLINE poly8x16x4_t vld4q_p8(const poly8_t *ptr) { return vld4q_u8(ptr); }
+FORCE_INLINE poly8x16x4_t vld4q_p8(const poly8_t *ptr) { return __riscv_vlseg4e8_v_u8m1x4(ptr, 16); }
 
 FORCE_INLINE poly16x4x4_t vld4_p16(const poly16_t *ptr) { return vld4_u16(ptr); }
 
-FORCE_INLINE poly16x8x4_t vld4q_p16(const poly16_t *ptr) { return vld4q_u16(ptr); }
+FORCE_INLINE poly16x8x4_t vld4q_p16(const poly16_t *ptr) { return __riscv_vlseg4e16_v_u16m1x4(ptr, 8); }
 
 FORCE_INLINE uint8x16x4_t vld4q_u8(const uint8_t *a) { return __riscv_vlseg4e8_v_u8m1x4(a, 16); }
 
@@ -14759,7 +14793,14 @@ FORCE_INLINE float32x4x4_t vld4q_lane_f32(const float32_t *a, float32x4x4_t b, c
 
 FORCE_INLINE poly16x4x4_t vld4_lane_p16(const poly16_t *ptr, poly16x4x4_t src, const int lane) { return vld4_lane_u16(ptr, src, lane); }
 
-FORCE_INLINE poly16x8x4_t vld4q_lane_p16(const poly16_t *ptr, poly16x8x4_t src, const int lane) { return vld4q_lane_u16(ptr, src, lane); }
+FORCE_INLINE poly16x8x4_t vld4q_lane_p16(const poly16_t *ptr, poly16x8x4_t src, const int lane) {
+  vbool16_t mask = __riscv_vreinterpret_v_u8m1_b16(vdup_n_u8((uint8_t)(1 << lane)));
+  vuint16m1_t c0 = __riscv_vmerge_vxm_u16m1(__riscv_vget_v_u16m1x4_u16m1(src, 0), ptr[0], mask, 8);
+  vuint16m1_t c1 = __riscv_vmerge_vxm_u16m1(__riscv_vget_v_u16m1x4_u16m1(src, 1), ptr[1], mask, 8);
+  vuint16m1_t c2 = __riscv_vmerge_vxm_u16m1(__riscv_vget_v_u16m1x4_u16m1(src, 2), ptr[2], mask, 8);
+  vuint16m1_t c3 = __riscv_vmerge_vxm_u16m1(__riscv_vget_v_u16m1x4_u16m1(src, 3), ptr[3], mask, 8);
+  return __riscv_vcreate_v_u16m1x4(c0, c1, c2, c3);
+}
 
 FORCE_INLINE uint16x8x4_t vld4q_lane_u16(const uint16_t *a, uint16x8x4_t b, const int c) {
   vbool16_t mask = __riscv_vreinterpret_v_u8m1_b16(vdup_n_u8((uint8_t)(1 << c)));
@@ -15067,7 +15108,20 @@ FORCE_INLINE void vst4q_lane_f32(float32_t *a, float32x4x4_t b, const int c) {
 
 FORCE_INLINE void vst4_lane_p16(poly16_t *ptr, poly16x4x4_t val, const int lane) { vst4_lane_u16(ptr, val, lane); }
 
-FORCE_INLINE void vst4q_lane_p16(poly16_t *ptr, poly16x8x4_t val, const int lane) { vst4q_lane_u16(ptr, val, lane); }
+FORCE_INLINE void vst4q_lane_p16(poly16_t *ptr, poly16x8x4_t val, const int lane) {
+  vuint16m1_t b0 = __riscv_vget_v_u16m1x4_u16m1(val, 0);
+  vuint16m1_t b1 = __riscv_vget_v_u16m1x4_u16m1(val, 1);
+  vuint16m1_t b2 = __riscv_vget_v_u16m1x4_u16m1(val, 2);
+  vuint16m1_t b3 = __riscv_vget_v_u16m1x4_u16m1(val, 3);
+  uint16_t *_b0 = (uint16_t *)&b0;
+  uint16_t *_b1 = (uint16_t *)&b1;
+  uint16_t *_b2 = (uint16_t *)&b2;
+  uint16_t *_b3 = (uint16_t *)&b3;
+  ptr[0] = _b0[lane];
+  ptr[1] = _b1[lane];
+  ptr[2] = _b2[lane];
+  ptr[3] = _b3[lane];
+}
 
 // FORCE_INLINE void vst4q_lane_s8(int8_t * ptr, int8x16x4_t val, const int lane);
 

--- a/scripts/check-format.sh
+++ b/scripts/check-format.sh
@@ -1,10 +1,21 @@
 #!/usr/bin/env bash
 
-set -x
+set -euxo pipefail
+
+if command -v clang-format-17 >/dev/null 2>&1; then
+    CLANG_FORMAT=clang-format-17
+elif command -v clang-format >/dev/null 2>&1; then
+    CLANG_FORMAT=clang-format
+else
+    echo "clang-format is required but not installed" >&2
+    exit 127
+fi
+
+: "${SOURCES:=neon2rvv.h tests/*.cpp tests/*.h}"
 
 for file in ${SOURCES};
 do
-    clang-format-17 ${file} > expected-format
+    ${CLANG_FORMAT} ${file} > expected-format
     diff -u -p --label="${file}" --label="expected coding style" ${file} expected-format
 done
-exit $(clang-format-17 --output-replacements-xml ${SOURCES} | egrep -c "</replacement>")
+exit $(${CLANG_FORMAT} --output-replacements-xml ${SOURCES} | egrep -c "</replacement>")

--- a/tests/endian.h
+++ b/tests/endian.h
@@ -1,0 +1,14 @@
+/*
+ * Minimal endian.h shim for bare-metal RISC-V builds (riscv64-unknown-elf).
+ * Newlib does not ship endian.h; stm-arm-neon-ref.h needs __BYTE_ORDER and
+ * the __LITTLE_ENDIAN / __BIG_ENDIAN constants.  RISC-V is always LE.
+ */
+#ifndef _ENDIAN_H
+#define _ENDIAN_H
+
+#define __LITTLE_ENDIAN 1234
+#define __BIG_ENDIAN    4321
+#define __PDP_ENDIAN    3412
+#define __BYTE_ORDER    __LITTLE_ENDIAN
+
+#endif /* _ENDIAN_H */

--- a/tests/neon_stubs.c
+++ b/tests/neon_stubs.c
@@ -1,0 +1,9 @@
+/*
+ * Empty stubs for the non-NEON (integer/DSP) test functions declared in
+ * arm-neon-tests/compute_ref.c.  Those functions are only meaningful when
+ * running on an ARM RVCT toolchain; neon2rvv does not implement them so we
+ * provide no-op definitions to satisfy the linker when targeting RISC-V.
+ */
+void exec_integer(void) {}
+void exec_dsp(void) {}
+void exec_dspfns(void) {}

--- a/tests/stm-arm-neon.h
+++ b/tests/stm-arm-neon.h
@@ -1,0 +1,6 @@
+/*
+ * Shim header used by the arm-neon-tests suite when building on non-ARM
+ * platforms.  Redirect to neon2rvv so the test harness exercises our RVV
+ * implementation rather than native ARM NEON.
+ */
+#include "../neon2rvv.h"

--- a/tests/stm-arm-neon.h
+++ b/tests/stm-arm-neon.h
@@ -4,3 +4,56 @@
  * implementation rather than native ARM NEON.
  */
 #include "../neon2rvv.h"
+
+#if defined(__riscv) || defined(__riscv__)
+/*
+ * The arm-neon-tests reference header (stm-arm-neon-ref.h) contains an
+ * ARM-specific inline assembly block guarded by #ifndef STM_ARM_NEON_MODELS
+ * that reads FPSCR via `vmrs` to detect the QC (saturation) flag.  On
+ * RISC-V we can't emit that instruction, so we define STM_ARM_NEON_MODELS
+ * to suppress that block and provide our own implementation using the
+ * RISC-V vxsat CSR (which is set by saturating vector instructions).
+ */
+#define STM_ARM_NEON_MODELS 1
+
+#include <stdint.h>
+
+/* Union matching the layout expected by the test harness. */
+typedef union {
+  struct {
+    int _xxx : 27;
+    unsigned int QC : 1;
+    int V : 1;
+    int C : 1;
+    int Z : 1;
+    int N : 1;
+  } b;
+  unsigned int word;
+} _ARM_FPSCR;
+
+/*
+ * Read the RISC-V vxsat CSR (bit 0 = saturation flag).
+ * Returns non-zero when any saturating operation has set the flag.
+ */
+static inline int __riscv_read_neon_sat(void) {
+  unsigned long r;
+  __asm__ volatile("csrr %0, vxsat" : "=r"(r));
+  return (int)(r & 1u);
+}
+
+/*
+ * Write the RISC-V vxsat CSR.
+ */
+static inline void __riscv_write_neon_sat(int val) {
+  unsigned long v = (unsigned long)(unsigned int)val;
+  __asm__ volatile("csrw vxsat, %0" : : "r"(v));
+}
+
+#define Neon_Cumulative_Sat __riscv_read_neon_sat()
+#define Set_Neon_Cumulative_Sat(x, depend) \
+  do {                                     \
+    (void)(depend);                        \
+    __riscv_write_neon_sat(x);             \
+  } while (0)
+
+#endif /* __riscv */


### PR DESCRIPTION
- Add christophe-lyon/arm-neon-tests as a git submodule under tests/arm-neon-tests/
- tests/stm-arm-neon.h: shim that redirects the test suite's non-ARM include path to neon2rvv.h
- tests/neon_stubs.c: empty stubs for exec_integer/dsp/dspfns (non-NEON ARM intrinsics not covered by neon2rvv)
- Makefile: add build-arm-neon-tests and check-arm-neon-tests targets that compile ~110 ref_*.c files against neon2rvv and diff the output against the upstream reference (ref-rvct-neon-nofp16.txt)
- github_actions.yml: new arm_neon_tests job using the existing RISC-V toolchain; also enable submodules: recursive on cross_compile_tests