### PR TITLE
chore: Auto-update coverage badge in CI

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -59,3 +59,24 @@ jobs:
             sudo apt-get install -q -y clang-format
             bash scripts/check-format.sh
         shell: bash
+
+  update_coverage_badge:
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v3.2.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: update coverage badge
+        run: python3 scripts/intrinsics_coverage.py --update-readme
+      - name: commit badge if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git diff --quiet README.md || (
+            git add README.md &&
+            git commit -m "chore: Update coverage badge [skip ci]"
+          )
+      - name: push changes
+        run: git push

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![coverage badge](https://img.shields.io/badge/coverage-80.1%25-brightgreen)
+![coverage badge](https://img.shields.io/badge/coverage-79.2%25-green)
 # neon2rvv
 
 A C/C++ header file that converts Arm/Aarch64 NEON intrinsics to RISC-V Vector (RVV) Extension.

--- a/scripts/intrinsics_coverage.py
+++ b/scripts/intrinsics_coverage.py
@@ -1,4 +1,6 @@
+import argparse
 import os
+import re
 import subprocess
 
 def get_git_root():
@@ -10,20 +12,52 @@ def read_file(file_path):
 
 def expect_impl(s):
     not_impl_list = ["p8", "p16", "p32", "p64", "p128", "f16"]
-
-    # print the intrinsics that haven't implemented by expected to
-    # if not any(not_impl in s for not_impl in not_impl_list):
-    #     if ("// FORCE_INLINE" in s):
-    #         print(s)
     return not any(not_impl in s for not_impl in not_impl_list)
 
 def is_impl(s):
     return not("// FORCE_INLINE" in s)
 
+def badge_color(pct):
+    if pct >= 90:
+        return "brightgreen"
+    if pct >= 75:
+        return "green"
+    if pct >= 60:
+        return "yellowgreen"
+    if pct >= 50:
+        return "yellow"
+    return "red"
+
+def update_readme(git_root, pct):
+    readme_path = os.path.join(git_root, "README.md")
+    with open(readme_path, 'r') as f:
+        content = f.read()
+
+    color = badge_color(pct)
+    pct_str = f"{pct:.1f}"
+    new_badge = f"![coverage badge](https://img.shields.io/badge/coverage-{pct_str}%25-{color})"
+    new_content = re.sub(
+        r'!\[coverage badge\]\(https://img\.shields\.io/badge/coverage-[^)]+\)',
+        new_badge,
+        content
+    )
+
+    if new_content != content:
+        with open(readme_path, 'w') as f:
+            f.write(new_content)
+        print(f"README.md updated: {pct_str}% ({color})")
+    else:
+        print("README.md already up to date.")
+
 def main():
+    parser = argparse.ArgumentParser(description="Calculate neon2rvv intrinsics coverage.")
+    parser.add_argument("--update-readme", action="store_true",
+                        help="Update the coverage badge in README.md")
+    args = parser.parse_args()
+
     git_root = get_git_root()
     file_path = os.path.join(git_root, "neon2rvv.h")
-    
+
     try:
         data = read_file(file_path)
     except IOError as e:
@@ -34,9 +68,15 @@ def main():
 
     expected_impl_cnt = sum(1 for line in mother if expect_impl(line))
     is_impl_cnt = sum(1 for line in mother if is_impl(line))
-    print("expected_impl_cnt: ", expected_impl_cnt)
-    print("is_impl_cnt: ", is_impl_cnt)
-    print("ratio: ", float(is_impl_cnt) / float(expected_impl_cnt))
+    ratio = float(is_impl_cnt) / float(expected_impl_cnt)
+    pct = ratio * 100
+
+    print(f"expected_impl_cnt:  {expected_impl_cnt}")
+    print(f"is_impl_cnt:        {is_impl_cnt}")
+    print(f"ratio:              {ratio:.4f}  ({pct:.1f}%)")
+
+    if args.update_readme:
+        update_readme(git_root, pct)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
- Add GitHub Actions job to update README badge on push to main
- Add --update-readme flag to intrinsics_coverage.py to patch badge in-place
- Improve output formatting with f-strings and badge color thresholds