### PR TITLE
feat: Impl vqdmulh[h]_lane[q]_[s16|s32]

### DIFF
--- a/neon2rvv.h
+++ b/neon2rvv.h
@@ -987,36 +987,34 @@ FORCE_INLINE uint32x4_t vmulq_u32(uint32x4_t a, uint32x4_t b) { return __riscv_v
 
 FORCE_INLINE int16x4_t vqdmulh_s16(int16x4_t a, int16x4_t b) {
   vint32m2_t ab_mul = __riscv_vwmul_vv_i32m2(a, b, 4);
-  vint32m2_t ab_mulx2 = __riscv_vmul_vx_i32m2(ab_mul, 2, 4);
-  return __riscv_vnsra_wx_i16m1(ab_mulx2, 16, 4);
+  return __riscv_vnclip_wx_i16m1(ab_mul, 15, __RISCV_VXRM_RDN, 4);
 }
 
 FORCE_INLINE int32x2_t vqdmulh_s32(int32x2_t a, int32x2_t b) {
   vint64m2_t ab_mul = __riscv_vwmul_vv_i64m2(a, b, 2);
-  vint64m2_t ab_mulx2 = __riscv_vmul_vx_i64m2(ab_mul, 2, 2);
-  return __riscv_vnsra_wx_i32m1(ab_mulx2, 32, 2);
+  return __riscv_vnclip_wx_i32m1(ab_mul, 31, __RISCV_VXRM_RDN, 2);
 }
 
 FORCE_INLINE int16x8_t vqdmulhq_s16(int16x8_t a, int16x8_t b) {
   vint32m2_t ab_mul = __riscv_vwmul_vv_i32m2(a, b, 8);
-  vint32m2_t ab_mulx2 = __riscv_vmul_vx_i32m2(ab_mul, 2, 8);
-  return __riscv_vnsra_wx_i16m1(ab_mulx2, 16, 8);
+  return __riscv_vnclip_wx_i16m1(ab_mul, 15, __RISCV_VXRM_RDN, 8);
 }
 
 FORCE_INLINE int32x4_t vqdmulhq_s32(int32x4_t a, int32x4_t b) {
   vint64m2_t ab_mul = __riscv_vwmul_vv_i64m2(a, b, 4);
-  vint64m2_t ab_mulx2 = __riscv_vmul_vx_i64m2(ab_mul, 2, 4);
-  return __riscv_vnsra_wx_i32m1(ab_mulx2, 32, 4);
+  return __riscv_vnclip_wx_i32m1(ab_mul, 31, __RISCV_VXRM_RDN, 4);
 }
 
 FORCE_INLINE int16_t vqdmulhh_s16(int16_t a, int16_t b) {
-  int32_t unsat = 2 * (int32_t)a * (int32_t)b;
-  return unsat >> 16;
+  int32_t product = (int32_t)a * (int32_t)b;
+  int32_t result = product >> 15;
+  return result > INT16_MAX ? INT16_MAX : (int16_t)result;
 }
 
 FORCE_INLINE int32_t vqdmulhs_s32(int32_t a, int32_t b) {
-  int64_t unsat = 2 * (int64_t)a * (int64_t)b;
-  return unsat >> 32;
+  int64_t product = (int64_t)a * (int64_t)b;
+  int64_t result = product >> 31;
+  return result > INT32_MAX ? INT32_MAX : (int32_t)result;
 }
 
 FORCE_INLINE int16x4_t vqrdmulh_s16(int16x4_t a, int16x4_t b) {
@@ -10177,45 +10175,77 @@ FORCE_INLINE int64x2_t vqdmull_high_laneq_s32(int32x4_t a, int32x4_t b, const in
 FORCE_INLINE int16x8_t vqdmulhq_lane_s16(int16x8_t a, int16x4_t b, const int c) {
   vint16m1_t b_dup_lane = __riscv_vrgather_vx_i16m1(b, c, 8);
   vint32m2_t ab_mul = __riscv_vwmul_vv_i32m2(a, b_dup_lane, 8);
-  vint32m2_t ab_mulx2 = __riscv_vmul_vx_i32m2(ab_mul, 2, 8);
-  return __riscv_vnsra_wx_i16m1(ab_mulx2, 16, 8);
+  return __riscv_vnclip_wx_i16m1(ab_mul, 15, __RISCV_VXRM_RDN, 8);
 }
 
 FORCE_INLINE int32x4_t vqdmulhq_lane_s32(int32x4_t a, int32x2_t b, const int c) {
   vint32m1_t b_dup_lane = __riscv_vrgather_vx_i32m1(b, c, 4);
   vint64m2_t ab_mul = __riscv_vwmul_vv_i64m2(a, b_dup_lane, 4);
-  vint64m2_t ab_mulx2 = __riscv_vmul_vx_i64m2(ab_mul, 2, 4);
-  return __riscv_vnsra_wx_i32m1(ab_mulx2, 32, 4);
+  return __riscv_vnclip_wx_i32m1(ab_mul, 31, __RISCV_VXRM_RDN, 4);
 }
 
-// FORCE_INLINE int16_t vqdmulhh_lane_s16(int16_t a, int16x4_t v, const int lane);
+FORCE_INLINE int16_t vqdmulhh_lane_s16(int16_t a, int16x4_t v, const int lane) {
+  int16_t v_lane = vget_lane_s16(v, lane);
+  int32_t product = (int32_t)a * (int32_t)v_lane;
+  int32_t result = product >> 15;
+  return result > INT16_MAX ? INT16_MAX : (int16_t)result;
+}
 
-// FORCE_INLINE int32_t vqdmulhs_lane_s32(int32_t a, int32x2_t v, const int lane);
+FORCE_INLINE int32_t vqdmulhs_lane_s32(int32_t a, int32x2_t v, const int lane) {
+  int32_t v_lane = vget_lane_s32(v, lane);
+  int64_t product = (int64_t)a * (int64_t)v_lane;
+  int64_t result = product >> 31;
+  return result > INT32_MAX ? INT32_MAX : (int32_t)result;
+}
 
-// FORCE_INLINE int16x4_t vqdmulh_laneq_s16(int16x4_t a, int16x8_t v, const int lane);
+FORCE_INLINE int16x4_t vqdmulh_laneq_s16(int16x4_t a, int16x8_t v, const int lane) {
+  vint16m1_t v_dup_lane = __riscv_vrgather_vx_i16m1(v, lane, 8);
+  vint32m2_t av_mul = __riscv_vwmul_vv_i32m2(a, v_dup_lane, 4);
+  return __riscv_vnclip_wx_i16m1(av_mul, 15, __RISCV_VXRM_RDN, 4);
+}
 
-// FORCE_INLINE int16x8_t vqdmulhq_laneq_s16(int16x8_t a, int16x8_t v, const int lane);
+FORCE_INLINE int16x8_t vqdmulhq_laneq_s16(int16x8_t a, int16x8_t v, const int lane) {
+  vint16m1_t v_dup_lane = __riscv_vrgather_vx_i16m1(v, lane, 8);
+  vint32m2_t av_mul = __riscv_vwmul_vv_i32m2(a, v_dup_lane, 8);
+  return __riscv_vnclip_wx_i16m1(av_mul, 15, __RISCV_VXRM_RDN, 8);
+}
 
-// FORCE_INLINE int32x2_t vqdmulh_laneq_s32(int32x2_t a, int32x4_t v, const int lane);
+FORCE_INLINE int32x2_t vqdmulh_laneq_s32(int32x2_t a, int32x4_t v, const int lane) {
+  vint32m1_t v_dup_lane = __riscv_vrgather_vx_i32m1(v, lane, 4);
+  vint64m2_t av_mul = __riscv_vwmul_vv_i64m2(a, v_dup_lane, 2);
+  return __riscv_vnclip_wx_i32m1(av_mul, 31, __RISCV_VXRM_RDN, 2);
+}
 
-// FORCE_INLINE int32x4_t vqdmulhq_laneq_s32(int32x4_t a, int32x4_t v, const int lane);
+FORCE_INLINE int32x4_t vqdmulhq_laneq_s32(int32x4_t a, int32x4_t v, const int lane) {
+  vint32m1_t v_dup_lane = __riscv_vrgather_vx_i32m1(v, lane, 4);
+  vint64m2_t av_mul = __riscv_vwmul_vv_i64m2(a, v_dup_lane, 4);
+  return __riscv_vnclip_wx_i32m1(av_mul, 31, __RISCV_VXRM_RDN, 4);
+}
 
-// FORCE_INLINE int16_t vqdmulhh_laneq_s16(int16_t a, int16x8_t v, const int lane);
+FORCE_INLINE int16_t vqdmulhh_laneq_s16(int16_t a, int16x8_t v, const int lane) {
+  int16_t v_lane = vgetq_lane_s16(v, lane);
+  int32_t product = (int32_t)a * (int32_t)v_lane;
+  int32_t result = product >> 15;
+  return result > INT16_MAX ? INT16_MAX : (int16_t)result;
+}
 
-// FORCE_INLINE int32_t vqdmulhs_laneq_s32(int32_t a, int32x4_t v, const int lane);
+FORCE_INLINE int32_t vqdmulhs_laneq_s32(int32_t a, int32x4_t v, const int lane) {
+  int32_t v_lane = vgetq_lane_s32(v, lane);
+  int64_t product = (int64_t)a * (int64_t)v_lane;
+  int64_t result = product >> 31;
+  return result > INT32_MAX ? INT32_MAX : (int32_t)result;
+}
 
 FORCE_INLINE int16x4_t vqdmulh_lane_s16(int16x4_t a, int16x4_t b, const int c) {
   vint16m1_t b_dup_lane = __riscv_vrgather_vx_i16m1(b, c, 4);
   vint32m2_t ab_mul = __riscv_vwmul_vv_i32m2(a, b_dup_lane, 4);
-  vint32m2_t ab_mulx2 = __riscv_vmul_vx_i32m2(ab_mul, 2, 4);
-  return __riscv_vnsra_wx_i16m1(ab_mulx2, 16, 4);
+  return __riscv_vnclip_wx_i16m1(ab_mul, 15, __RISCV_VXRM_RDN, 4);
 }
 
 FORCE_INLINE int32x2_t vqdmulh_lane_s32(int32x2_t a, int32x2_t b, const int c) {
   vint32m1_t b_dup_lane = __riscv_vrgather_vx_i32m1(b, c, 2);
   vint64m2_t ab_mul = __riscv_vwmul_vv_i64m2(a, b_dup_lane, 2);
-  vint64m2_t ab_mulx2 = __riscv_vmul_vx_i64m2(ab_mul, 2, 2);
-  return __riscv_vnsra_wx_i32m1(ab_mulx2, 32, 2);
+  return __riscv_vnclip_wx_i32m1(ab_mul, 31, __RISCV_VXRM_RDN, 2);
 }
 
 FORCE_INLINE int16x8_t vqrdmulhq_lane_s16(int16x8_t a, int16x4_t b, const int c) {

--- a/tests/impl.cpp
+++ b/tests/impl.cpp
@@ -3286,7 +3286,7 @@ result_t test_vqdmulh_s16(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
   const int16_t *_b = (int16_t *)impl.test_cases_int_pointer2;
   int16_t _c[4];
   for (int i = 0; i < 4; i++) {
-    _c[i] = saturate_int16(2 * (int32_t)_a[i] * (int32_t)_b[i] >> 16);
+    _c[i] = saturate_int16((int32_t)_a[i] * (int32_t)_b[i] >> 15);
   }
 
   int16x4_t a = vld1_s16(_a);
@@ -3304,7 +3304,7 @@ result_t test_vqdmulh_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
   const int32_t *_b = (int32_t *)impl.test_cases_int_pointer2;
   int32_t _c[2];
   for (int i = 0; i < 2; i++) {
-    _c[i] = saturate_int32(2 * (int64_t)_a[i] * (int64_t)_b[i] >> 32);
+    _c[i] = saturate_int32((int64_t)_a[i] * (int64_t)_b[i] >> 31);
   }
 
   int32x2_t a = vld1_s32(_a);
@@ -3322,7 +3322,7 @@ result_t test_vqdmulhq_s16(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
   const int16_t *_b = (int16_t *)impl.test_cases_int_pointer2;
   int16_t _c[8];
   for (int i = 0; i < 8; i++) {
-    _c[i] = saturate_int16(2 * (int32_t)_a[i] * (int32_t)_b[i] >> 16);
+    _c[i] = saturate_int16((int32_t)_a[i] * (int32_t)_b[i] >> 15);
   }
 
   int16x8_t a = vld1q_s16(_a);
@@ -3340,7 +3340,7 @@ result_t test_vqdmulhq_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
   const int32_t *_b = (int32_t *)impl.test_cases_int_pointer2;
   int32_t _c[4];
   for (int i = 0; i < 4; i++) {
-    _c[i] = saturate_int32(2 * (int64_t)_a[i] * (int64_t)_b[i] >> 32);
+    _c[i] = saturate_int32((int64_t)_a[i] * (int64_t)_b[i] >> 31);
   }
 
   int32x4_t a = vld1q_s32(_a);
@@ -3356,7 +3356,7 @@ result_t test_vqdmulhh_s16(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
 #ifdef ENABLE_TEST_ALL
   const int16_t *_a = (int16_t *)impl.test_cases_int_pointer1;
   const int16_t *_b = (int16_t *)impl.test_cases_int_pointer2;
-  int16_t _c = saturate_int16(2 * (int32_t)_a[0] * (int32_t)_b[0] >> 16);
+  int16_t _c = saturate_int16((int32_t)_a[0] * (int32_t)_b[0] >> 15);
 
   int16_t c = vqdmulhh_s16(_a[0], _b[0]);
   return c == _c ? TEST_SUCCESS : TEST_FAIL;
@@ -3369,7 +3369,7 @@ result_t test_vqdmulhs_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
 #ifdef ENABLE_TEST_ALL
   const int32_t *_a = (int32_t *)impl.test_cases_int_pointer1;
   const int32_t *_b = (int32_t *)impl.test_cases_int_pointer2;
-  int32_t _c = saturate_int32(2 * (int64_t)_a[0] * (int64_t)_b[0] >> 32);
+  int32_t _c = saturate_int32((int64_t)_a[0] * (int64_t)_b[0] >> 31);
 
   int32_t c = vqdmulhs_s32(_a[0], _b[0]);
   return c == _c ? TEST_SUCCESS : TEST_FAIL;
@@ -36480,14 +36480,14 @@ result_t test_vqdmulhq_lane_s16(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
   int16x4_t b;
   int16_t _c[8];
 
-#define TEST_IMPL(IDX)                                                   \
-  for (int i = 0; i < 8; i++) {                                          \
-    _c[i] = saturate_int16(2 * (int32_t)_a[i] * (int32_t)_b[IDX] >> 16); \
-  }                                                                      \
-                                                                         \
-  a = vld1q_s16(_a);                                                     \
-  b = vld1_s16(_b);                                                      \
-  c = vqdmulhq_lane_s16(a, b, IDX);                                      \
+#define TEST_IMPL(IDX)                                                        \
+  for (int i = 0; i < 8; i++) {                                               \
+    _c[i] = saturate_int16((int32_t)_a[i] * (int32_t)_b[IDX] >> 15);        \
+  }                                                                            \
+                                                                               \
+  a = vld1q_s16(_a);                                                           \
+  b = vld1_s16(_b);                                                            \
+  c = vqdmulhq_lane_s16(a, b, IDX);                                           \
   CHECK_RESULT(validate_int16(c, _c[0], _c[1], _c[2], _c[3], _c[4], _c[5], _c[6], _c[7]))
 
   IMM_4_ITER
@@ -36507,14 +36507,14 @@ result_t test_vqdmulhq_lane_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
   int32x2_t b;
   int32_t _c[4];
 
-#define TEST_IMPL(IDX)                                                   \
-  for (int i = 0; i < 4; i++) {                                          \
-    _c[i] = saturate_int32(2 * (int64_t)_a[i] * (int64_t)_b[IDX] >> 32); \
-  }                                                                      \
-                                                                         \
-  a = vld1q_s32(_a);                                                     \
-  b = vld1_s32(_b);                                                      \
-  c = vqdmulhq_lane_s32(a, b, IDX);                                      \
+#define TEST_IMPL(IDX)                                                        \
+  for (int i = 0; i < 4; i++) {                                               \
+    _c[i] = saturate_int32((int64_t)_a[i] * (int64_t)_b[IDX] >> 31);        \
+  }                                                                            \
+                                                                               \
+  a = vld1q_s32(_a);                                                           \
+  b = vld1_s32(_b);                                                            \
+  c = vqdmulhq_lane_s32(a, b, IDX);                                           \
   CHECK_RESULT(validate_int32(c, _c[0], _c[1], _c[2], _c[3]))
 
   IMM_2_ITER
@@ -36526,21 +36526,192 @@ result_t test_vqdmulhq_lane_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
 #endif  // ENABLE_TEST_ALL
 }
 
-result_t test_vqdmulhh_lane_s16(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+result_t test_vqdmulhh_lane_s16(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const int16_t *_a = (int16_t *)impl.test_cases_int_pointer1;
+  const int16_t *_b = (int16_t *)impl.test_cases_int_pointer2;
+  int16x4_t v = vld1_s16(_b);
+  int16_t c, _c;
 
-result_t test_vqdmulhs_lane_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+#define TEST_IMPL(IDX)                                                        \
+  _c = saturate_int16((int32_t)_a[0] * (int32_t)_b[IDX] >> 15);             \
+  c = vqdmulhh_lane_s16(_a[0], v, IDX);                                       \
+  CHECK_RESULT(c == _c ? TEST_SUCCESS : TEST_FAIL)
 
-result_t test_vqdmulh_laneq_s16(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+  IMM_4_ITER
+#undef TEST_IMPL
 
-result_t test_vqdmulhq_laneq_s16(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+  return TEST_SUCCESS;
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
 
-result_t test_vqdmulh_laneq_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+result_t test_vqdmulhs_lane_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const int32_t *_a = (int32_t *)impl.test_cases_int_pointer1;
+  const int32_t *_b = (int32_t *)impl.test_cases_int_pointer2;
+  int32x2_t v = vld1_s32(_b);
+  int32_t c, _c;
 
-result_t test_vqdmulhq_laneq_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+#define TEST_IMPL(IDX)                                                       \
+  _c = saturate_int32((int64_t)_a[0] * (int64_t)_b[IDX] >> 31);            \
+  c = vqdmulhs_lane_s32(_a[0], v, IDX);                                      \
+  CHECK_RESULT(c == _c ? TEST_SUCCESS : TEST_FAIL)
 
-result_t test_vqdmulhh_laneq_s16(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+  IMM_2_ITER
+#undef TEST_IMPL
 
-result_t test_vqdmulhs_laneq_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) { return TEST_UNIMPL; }
+  return TEST_SUCCESS;
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
+
+result_t test_vqdmulh_laneq_s16(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const int16_t *_a = (int16_t *)impl.test_cases_int_pointer1;
+  const int16_t *_b = (int16_t *)impl.test_cases_int_pointer2;
+  int16x4_t a;
+  int16x8_t v;
+  int16x4_t c;
+  int16_t _c[4];
+
+#define TEST_IMPL(IDX)                                                        \
+  for (int i = 0; i < 4; i++) {                                               \
+    _c[i] = saturate_int16((int32_t)_a[i] * (int32_t)_b[IDX] >> 15);        \
+  }                                                                            \
+  a = vld1_s16(_a);                                                            \
+  v = vld1q_s16(_b);                                                           \
+  c = vqdmulh_laneq_s16(a, v, IDX);                                           \
+  CHECK_RESULT(validate_int16(c, _c[0], _c[1], _c[2], _c[3]))
+
+  IMM_8_ITER
+#undef TEST_IMPL
+
+  return TEST_SUCCESS;
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
+
+result_t test_vqdmulhq_laneq_s16(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const int16_t *_a = (int16_t *)impl.test_cases_int_pointer1;
+  const int16_t *_b = (int16_t *)impl.test_cases_int_pointer2;
+  int16x8_t a, v, c;
+  int16_t _c[8];
+
+#define TEST_IMPL(IDX)                                                        \
+  for (int i = 0; i < 8; i++) {                                               \
+    _c[i] = saturate_int16((int32_t)_a[i] * (int32_t)_b[IDX] >> 15);        \
+  }                                                                            \
+  a = vld1q_s16(_a);                                                           \
+  v = vld1q_s16(_b);                                                           \
+  c = vqdmulhq_laneq_s16(a, v, IDX);                                          \
+  CHECK_RESULT(validate_int16(c, _c[0], _c[1], _c[2], _c[3], _c[4], _c[5], _c[6], _c[7]))
+
+  IMM_8_ITER
+#undef TEST_IMPL
+
+  return TEST_SUCCESS;
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
+
+result_t test_vqdmulh_laneq_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const int32_t *_a = (int32_t *)impl.test_cases_int_pointer1;
+  const int32_t *_b = (int32_t *)impl.test_cases_int_pointer2;
+  int32x2_t a, c;
+  int32x4_t v;
+  int32_t _c[2];
+
+#define TEST_IMPL(IDX)                                                        \
+  for (int i = 0; i < 2; i++) {                                               \
+    _c[i] = saturate_int32((int64_t)_a[i] * (int64_t)_b[IDX] >> 31);        \
+  }                                                                            \
+  a = vld1_s32(_a);                                                            \
+  v = vld1q_s32(_b);                                                           \
+  c = vqdmulh_laneq_s32(a, v, IDX);                                           \
+  CHECK_RESULT(validate_int32(c, _c[0], _c[1]))
+
+  IMM_4_ITER
+#undef TEST_IMPL
+
+  return TEST_SUCCESS;
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
+
+result_t test_vqdmulhq_laneq_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const int32_t *_a = (int32_t *)impl.test_cases_int_pointer1;
+  const int32_t *_b = (int32_t *)impl.test_cases_int_pointer2;
+  int32x4_t a, v, c;
+  int32_t _c[4];
+
+#define TEST_IMPL(IDX)                                                        \
+  for (int i = 0; i < 4; i++) {                                               \
+    _c[i] = saturate_int32((int64_t)_a[i] * (int64_t)_b[IDX] >> 31);        \
+  }                                                                            \
+  a = vld1q_s32(_a);                                                           \
+  v = vld1q_s32(_b);                                                           \
+  c = vqdmulhq_laneq_s32(a, v, IDX);                                          \
+  CHECK_RESULT(validate_int32(c, _c[0], _c[1], _c[2], _c[3]))
+
+  IMM_4_ITER
+#undef TEST_IMPL
+
+  return TEST_SUCCESS;
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
+
+result_t test_vqdmulhh_laneq_s16(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const int16_t *_a = (int16_t *)impl.test_cases_int_pointer1;
+  const int16_t *_b = (int16_t *)impl.test_cases_int_pointer2;
+  int16x8_t v = vld1q_s16(_b);
+  int16_t c, _c;
+
+#define TEST_IMPL(IDX)                                                        \
+  _c = saturate_int16((int32_t)_a[0] * (int32_t)_b[IDX] >> 15);             \
+  c = vqdmulhh_laneq_s16(_a[0], v, IDX);                                      \
+  CHECK_RESULT(c == _c ? TEST_SUCCESS : TEST_FAIL)
+
+  IMM_8_ITER
+#undef TEST_IMPL
+
+  return TEST_SUCCESS;
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
+
+result_t test_vqdmulhs_laneq_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
+#ifdef ENABLE_TEST_ALL
+  const int32_t *_a = (int32_t *)impl.test_cases_int_pointer1;
+  const int32_t *_b = (int32_t *)impl.test_cases_int_pointer2;
+  int32x4_t v = vld1q_s32(_b);
+  int32_t c, _c;
+
+#define TEST_IMPL(IDX)                                                       \
+  _c = saturate_int32((int64_t)_a[0] * (int64_t)_b[IDX] >> 31);            \
+  c = vqdmulhs_laneq_s32(_a[0], v, IDX);                                     \
+  CHECK_RESULT(c == _c ? TEST_SUCCESS : TEST_FAIL)
+
+  IMM_4_ITER
+#undef TEST_IMPL
+
+  return TEST_SUCCESS;
+#else
+  return TEST_UNIMPL;
+#endif  // ENABLE_TEST_ALL
+}
 
 result_t test_vqdmulh_lane_s16(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
 #ifdef ENABLE_TEST_ALL
@@ -36549,13 +36720,13 @@ result_t test_vqdmulh_lane_s16(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
   int16x4_t a, b, c;
   int16_t _c[4];
 
-#define TEST_IMPL(IDX)                                                   \
-  for (int i = 0; i < 4; i++) {                                          \
-    _c[i] = saturate_int16(2 * (int32_t)_a[i] * (int32_t)_b[IDX] >> 16); \
-  }                                                                      \
-  a = vld1_s16(_a);                                                      \
-  b = vld1_s16(_b);                                                      \
-  c = vqdmulh_lane_s16(a, b, IDX);                                       \
+#define TEST_IMPL(IDX)                                                        \
+  for (int i = 0; i < 4; i++) {                                               \
+    _c[i] = saturate_int16((int32_t)_a[i] * (int32_t)_b[IDX] >> 15);        \
+  }                                                                            \
+  a = vld1_s16(_a);                                                            \
+  b = vld1_s16(_b);                                                            \
+  c = vqdmulh_lane_s16(a, b, IDX);                                            \
   CHECK_RESULT(validate_int16(c, _c[0], _c[1], _c[2], _c[3]))
 
   IMM_4_ITER
@@ -36574,13 +36745,13 @@ result_t test_vqdmulh_lane_s32(const NEON2RVV_TEST_IMPL &impl, uint32_t iter) {
   int32x2_t a, b, c;
   int32_t _c[2];
 
-#define TEST_IMPL(IDX)                                                   \
-  for (int i = 0; i < 2; i++) {                                          \
-    _c[i] = saturate_int32(2 * (int64_t)_a[i] * (int64_t)_b[IDX] >> 32); \
-  }                                                                      \
-  a = vld1_s32(_a);                                                      \
-  b = vld1_s32(_b);                                                      \
-  c = vqdmulh_lane_s32(a, b, IDX);                                       \
+#define TEST_IMPL(IDX)                                                        \
+  for (int i = 0; i < 2; i++) {                                               \
+    _c[i] = saturate_int32((int64_t)_a[i] * (int64_t)_b[IDX] >> 31);        \
+  }                                                                            \
+  a = vld1_s32(_a);                                                            \
+  b = vld1_s32(_b);                                                            \
+  c = vqdmulh_lane_s32(a, b, IDX);                                            \
   CHECK_RESULT(validate_int32(c, _c[0], _c[1]))
 
   IMM_2_ITER

--- a/tests/impl.h
+++ b/tests/impl.h
@@ -2036,14 +2036,14 @@
   _(vqdmull_high_laneq_s32)                                                      \
   _(vqdmulhq_lane_s16)                                                           \
   _(vqdmulhq_lane_s32)                                                           \
-  /*_(vqdmulhh_lane_s16)                                                      */ \
-  /*_(vqdmulhs_lane_s32)                                                      */ \
-  /*_(vqdmulh_laneq_s16)                                                      */ \
-  /*_(vqdmulhq_laneq_s16)                                                     */ \
-  /*_(vqdmulh_laneq_s32)                                                      */ \
-  /*_(vqdmulhq_laneq_s32)                                                     */ \
-  /*_(vqdmulhh_laneq_s16)                                                     */ \
-  /*_(vqdmulhs_laneq_s32)                                                     */ \
+  _(vqdmulhh_lane_s16)                                                           \
+  _(vqdmulhs_lane_s32)                                                           \
+  _(vqdmulh_laneq_s16)                                                           \
+  _(vqdmulhq_laneq_s16)                                                          \
+  _(vqdmulh_laneq_s32)                                                           \
+  _(vqdmulhq_laneq_s32)                                                          \
+  _(vqdmulhh_laneq_s16)                                                          \
+  _(vqdmulhs_laneq_s32)                                                          \
   _(vqdmulh_lane_s16)                                                            \
   _(vqdmulh_lane_s32)                                                            \
   _(vqrdmulhq_lane_s16)                                                          \


### PR DESCRIPTION
Implement the 8 missing vqdmulh lane variants:
- vqdmulhh_lane_s16, vqdmulhs_lane_s32 (scalar with lane from narrow vector)
- vqdmulhh_laneq_s16, vqdmulhs_laneq_s32 (scalar with lane from wide vector)
- vqdmulh_laneq_s16, vqdmulhq_laneq_s16 (vector with lane from wide vector)
- vqdmulh_laneq_s32, vqdmulhq_laneq_s32 (vector with lane from wide vector)

Add corresponding tests and enable them in the test list.